### PR TITLE
feat: 헤더 GNB 정적 화면 구현

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -5,6 +5,7 @@
   "dependencies": {
     "@emotion/react": "^11.9.0",
     "@emotion/styled": "^11.8.1",
+    "@mui/icons-material": "^5.8.0",
     "@mui/material": "^5.8.0",
     "@testing-library/jest-dom": "^5.14.1",
     "@testing-library/react": "^13.0.0",

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -7,8 +7,8 @@ import theme from "styles/theme";
 const App = (): JSX.Element => {
   return (
     <div className="App">
-      <CssBaseline />
       <ThemeProvider theme={theme}>
+        <CssBaseline />
         <Header />
       </ThemeProvider>
     </div>

--- a/frontend/src/components/Header/Header.styled.ts
+++ b/frontend/src/components/Header/Header.styled.ts
@@ -1,6 +1,9 @@
-// TODO: 검색결과 화면으로 변경시 다른 스타일이 적용되어야 함
+import { Container, ContainerProps } from "@mui/material";
+import { styled } from "@mui/material/styles";
+
 import heroImage from "assets/hero-img.png";
 
+// TODO: 검색결과 화면으로 변경시 다른 스타일이 적용되어야 함
 const indexHeaderStyle = {
   maxwidth: "1440px",
   height: "640px",
@@ -10,4 +13,12 @@ const indexHeaderStyle = {
   backgroundSize: "cover",
 };
 
-export default indexHeaderStyle;
+const HeaderContainer = styled(Container)<ContainerProps>(
+  ({ theme: { size, style, whiteSpace } }) => `
+  height: ${size.navBarHeight};
+  margin: ${style.alignCenter.margin};
+  padding: 0 ${whiteSpace.inner} !important;
+`
+);
+
+export { indexHeaderStyle, HeaderContainer };

--- a/frontend/src/components/Header/Header.styled.ts
+++ b/frontend/src/components/Header/Header.styled.ts
@@ -1,0 +1,13 @@
+// TODO: 검색결과 화면으로 변경시 다른 스타일이 적용되어야 함
+import heroImage from "assets/hero-img.png";
+
+const indexHeaderStyle = {
+  maxwidth: "1440px",
+  height: "640px",
+  backgroundImage: `url(${heroImage})`,
+  backgroundRepeat: "no-repeat",
+  backgroundPosition: "center bottom",
+  backgroundSize: "cover",
+};
+
+export default indexHeaderStyle;

--- a/frontend/src/components/Header/Header.tsx
+++ b/frontend/src/components/Header/Header.tsx
@@ -9,8 +9,10 @@ import UserMenu from "./UserMenu/UserMenu";
 const LogoArea = () => {
   return (
     <Grid container item xs={2} justifyContent="left">
-      <h1>
-        <a href="/">LOGO</a>
+      <h1 style={{ margin: "auto 0" }}>
+        <a href="/" title="첫 화면으로 이동">
+          LOGO
+        </a>
       </h1>
     </Grid>
   );

--- a/frontend/src/components/Header/Header.tsx
+++ b/frontend/src/components/Header/Header.tsx
@@ -2,20 +2,9 @@ import { Grid } from "@mui/material";
 import Box from "@mui/material/Box";
 import Container from "@mui/material/Container";
 
-import heroImage from "assets/hero-img.png";
-
 import GNB from "./GNB/GNB";
+import indexHeaderStyle from "./Header.styled";
 import UserMenu from "./UserMenu/UserMenu";
-
-// TODO: 검색결과 화면으로 변경시 다른 스타일이 적용되어야 함
-const indexHeaderStyle = {
-  maxwidth: "1440px",
-  height: "640px",
-  backgroundImage: `url(${heroImage})`,
-  backgroundRepeat: "no-repeat",
-  backgroundPosition: "center bottom",
-  backgroundSize: "cover",
-};
 
 const LogoArea = () => {
   return (
@@ -30,8 +19,13 @@ const LogoArea = () => {
 const Header = () => {
   return (
     <Box component="header" sx={indexHeaderStyle}>
-      <Container maxWidth="xl" sx={{ height: "100px" }}>
-        <Grid container spacing={2} columns={12}>
+      <Container maxWidth="xl" sx={{ height: ({ size }) => size.navBarHeight }}>
+        <Grid
+          container
+          spacing={2}
+          columns={12}
+          sx={{ height: ({ size }) => size.fullSize }}
+        >
           <LogoArea />
           <GNB />
           <UserMenu />

--- a/frontend/src/components/Header/Header.tsx
+++ b/frontend/src/components/Header/Header.tsx
@@ -20,7 +20,9 @@ const indexHeaderStyle = {
 const LogoArea = () => {
   return (
     <Grid container item xs={2} justifyContent="left">
-      <h1>LOGO</h1>
+      <h1>
+        <a href="/">LOGO</a>
+      </h1>
     </Grid>
   );
 };
@@ -28,7 +30,7 @@ const LogoArea = () => {
 const Header = () => {
   return (
     <Box component="header" sx={indexHeaderStyle}>
-      <Container component="header" maxWidth="xl" sx={{ height: "100px" }}>
+      <Container maxWidth="xl" sx={{ height: "100px" }}>
         <Grid container spacing={2} columns={12}>
           <LogoArea />
           <GNB />

--- a/frontend/src/components/Header/Header.tsx
+++ b/frontend/src/components/Header/Header.tsx
@@ -1,9 +1,8 @@
 import { Grid } from "@mui/material";
 import Box from "@mui/material/Box";
-import Container from "@mui/material/Container";
 
 import GNB from "./GNB/GNB";
-import indexHeaderStyle from "./Header.styled";
+import { indexHeaderStyle, HeaderContainer } from "./Header.styled";
 import UserMenu from "./UserMenu/UserMenu";
 
 const LogoArea = () => {
@@ -21,7 +20,7 @@ const LogoArea = () => {
 const Header = () => {
   return (
     <Box component="header" sx={indexHeaderStyle}>
-      <Container maxWidth="xl" sx={{ height: ({ size }) => size.navBarHeight }}>
+      <HeaderContainer maxWidth="xl">
         <Grid
           container
           spacing={2}
@@ -33,7 +32,7 @@ const Header = () => {
           <UserMenu />
         </Grid>
         {/* TODO: SearchBar */}
-      </Container>
+      </HeaderContainer>
     </Box>
   );
 };

--- a/frontend/src/components/Header/Header.tsx
+++ b/frontend/src/components/Header/Header.tsx
@@ -36,8 +36,8 @@ const Header = () => {
           <GNB />
           <UserMenu />
         </Grid>
+        {/* TODO: SearchBar */}
       </Container>
-      {/* TODO: SearchBar */}
     </Box>
   );
 };

--- a/frontend/src/components/Header/UserMenu/UserMenu.styled.ts
+++ b/frontend/src/components/Header/UserMenu/UserMenu.styled.ts
@@ -1,0 +1,12 @@
+import { Button, ButtonProps } from "@mui/material";
+import { styled } from "@mui/material/styles";
+
+const UserButton = styled(Button)<ButtonProps>(
+  ({ theme: { palette } }) => `
+:hover {
+  background-color: ${palette.white.main};
+}
+`
+);
+
+export default UserButton;

--- a/frontend/src/components/Header/UserMenu/UserMenu.styled.ts
+++ b/frontend/src/components/Header/UserMenu/UserMenu.styled.ts
@@ -1,10 +1,9 @@
-import { Button, ButtonProps, Container } from "@mui/material";
+import { Button, ButtonProps, Container, ContainerProps } from "@mui/material";
 import { styled } from "@mui/material/styles";
 
-const UserMenuContainer = styled(Container)(
+const UserMenuContainer = styled(Container)<ContainerProps>(
   ({ theme: { palette } }) => `
   background-color: ${palette.white.main};
-  margin: 0;
   width: 76px;
   height: 40px;
   border-radius: calc(76px / 2);

--- a/frontend/src/components/Header/UserMenu/UserMenu.styled.ts
+++ b/frontend/src/components/Header/UserMenu/UserMenu.styled.ts
@@ -1,12 +1,46 @@
-import { Button, ButtonProps } from "@mui/material";
+import { Button, ButtonProps, Container } from "@mui/material";
 import { styled } from "@mui/material/styles";
 
-const UserButton = styled(Button)<ButtonProps>(
+const UserMenuContainer = styled(Container)(
   ({ theme: { palette } }) => `
-:hover {
   background-color: ${palette.white.main};
-}
+  margin: 0;
+  width: 76px;
+  height: 40px;
+  border-radius: calc(76px / 2);
+  border: 1px solid ${palette.grey4.main};
+  display:flex;
+  justify-content: center;
+  align-items: center;
+  
+  @media (min-width: 600px) {
+    padding: 0;
+  }
 `
 );
 
-export default UserButton;
+const UserButton = styled(Button)<ButtonProps>(
+  ({ theme: { palette } }) => `
+  background-color: ${palette.grey3.main};
+  color: ${palette.white.main};
+  width: 32px;
+  height: 32px;
+  border-radius: 50%;
+
+  :hover {
+    background-color: ${palette.grey3.main};
+  }
+`
+);
+const MenuButton = styled(Button)<ButtonProps>(
+  ({ theme: { palette } }) => `
+  background-color: ${palette.white.main};
+  color: ${palette.grey3.main};
+  width: 32px;
+  height: 32px;
+  border-radius: 50%;
+
+`
+);
+
+export { MenuButton, UserButton, UserMenuContainer };

--- a/frontend/src/components/Header/UserMenu/UserMenu.styled.ts
+++ b/frontend/src/components/Header/UserMenu/UserMenu.styled.ts
@@ -2,29 +2,23 @@ import { Button, ButtonProps, Container, ContainerProps } from "@mui/material";
 import { styled } from "@mui/material/styles";
 
 const UserMenuContainer = styled(Container)<ContainerProps>(
-  ({ theme: { palette } }) => `
+  ({ theme: { palette, style } }) => `
+  ${style.alignCenter.flex}
   background-color: ${palette.white.main};
   width: 76px;
   height: 40px;
   border-radius: calc(76px / 2);
   border: 1px solid ${palette.grey4.main};
-  display:flex;
-  justify-content: center;
-  align-items: center;
-  
-  @media (min-width: 600px) {
-    padding: 0;
-  }
 `
 );
 
 const UserButton = styled(Button)<ButtonProps>(
-  ({ theme: { palette } }) => `
+  ({ theme: { palette, size, style } }) => `
   background-color: ${palette.grey3.main};
   color: ${palette.white.main};
-  width: 32px;
-  height: 32px;
-  border-radius: 50%;
+  width: ${size.userMenuButton.width};
+  height: ${size.userMenuButton.height};
+  ${style.circularBorder}
 
   :hover {
     background-color: ${palette.grey3.main};
@@ -32,12 +26,13 @@ const UserButton = styled(Button)<ButtonProps>(
 `
 );
 const MenuButton = styled(Button)<ButtonProps>(
-  ({ theme: { palette } }) => `
+  ({ theme: { palette, size, style } }) => `
   background-color: ${palette.white.main};
   color: ${palette.grey3.main};
-  width: 32px;
-  height: 32px;
-  border-radius: 50%;
+  width: ${size.userMenuButton.width};
+  height: ${size.userMenuButton.height};
+  ${style.circularBorder}
+
 
 `
 );

--- a/frontend/src/components/Header/UserMenu/UserMenu.styled.ts
+++ b/frontend/src/components/Header/UserMenu/UserMenu.styled.ts
@@ -1,5 +1,24 @@
-import { Button, ButtonProps, Container, ContainerProps } from "@mui/material";
+import { Container, ContainerProps, Avatar } from "@mui/material";
 import { styled } from "@mui/material/styles";
+
+const userMenuButtonStyle = {
+  padding: 0,
+  border: 0,
+  width: `calc(100% - 4px)`,
+  height: `calc(100% - 4px)`,
+  backgroundColor: "transparent",
+
+  "&:hover": {
+    backgroundColor: "transparent",
+  },
+};
+
+const menuIconStyle = {
+  color: ({ palette }: { palette: { grey3: { main: string } } }) =>
+    palette.grey3.main,
+  marginRight: ({ size }: { size: { userMenuButton: { width: string } } }) =>
+    size.userMenuButton.width,
+};
 
 const UserMenuContainer = styled(Container)<ContainerProps>(
   ({ theme: { palette, style } }) => `
@@ -9,32 +28,19 @@ const UserMenuContainer = styled(Container)<ContainerProps>(
   height: 40px;
   border-radius: calc(76px / 2);
   border: 1px solid ${palette.grey4.main};
+  position: relative;
 `
 );
 
-const UserButton = styled(Button)<ButtonProps>(
-  ({ theme: { palette, size, style } }) => `
+const UserAvatar = styled(Avatar)(
+  ({ theme: { palette, size } }) => `
   background-color: ${palette.grey3.main};
-  color: ${palette.white.main};
   width: ${size.userMenuButton.width};
   height: ${size.userMenuButton.height};
-  ${style.circularBorder}
-
-  :hover {
-    background-color: ${palette.grey3.main};
-  }
-`
-);
-const MenuButton = styled(Button)<ButtonProps>(
-  ({ theme: { palette, size, style } }) => `
-  background-color: ${palette.white.main};
-  color: ${palette.grey3.main};
-  width: ${size.userMenuButton.width};
-  height: ${size.userMenuButton.height};
-  ${style.circularBorder}
-
-
-`
+  position: absolute;
+  right: 0;
+}
+  );`
 );
 
-export { MenuButton, UserButton, UserMenuContainer };
+export { userMenuButtonStyle, menuIconStyle, UserMenuContainer, UserAvatar };

--- a/frontend/src/components/Header/UserMenu/UserMenu.tsx
+++ b/frontend/src/components/Header/UserMenu/UserMenu.tsx
@@ -15,12 +15,12 @@ const UserMenu = () => {
       alignItems="flex-end"
     >
       <UserMenuContainer>
-        <MenuButton disableFocusRipple disableRipple>
-          <MenuIcon />
-        </MenuButton>
-        <UserButton disableFocusRipple disableRipple>
-          <PersonIcon />
-        </UserButton>
+        <MenuButton startIcon={<MenuIcon />} disableFocusRipple disableRipple />
+        <UserButton
+          startIcon={<PersonIcon />}
+          disableFocusRipple
+          disableRipple
+        />
       </UserMenuContainer>
     </Grid>
   );

--- a/frontend/src/components/Header/UserMenu/UserMenu.tsx
+++ b/frontend/src/components/Header/UserMenu/UserMenu.tsx
@@ -1,7 +1,8 @@
+import MenuIcon from "@mui/icons-material/Menu";
 import PersonIcon from "@mui/icons-material/Person";
 import { Grid } from "@mui/material";
 
-import UserButton from "./UserMenu.styled";
+import { MenuButton, UserButton, UserMenuContainer } from "./UserMenu.styled";
 
 const UserMenu = () => {
   return (
@@ -13,14 +14,14 @@ const UserMenu = () => {
       direction="column"
       alignItems="flex-end"
     >
-      <UserButton
-        variant="contained"
-        color="white"
-        disableFocusRipple
-        disableRipple
-      >
-        <PersonIcon />
-      </UserButton>
+      <UserMenuContainer>
+        <MenuButton disableFocusRipple disableRipple>
+          <MenuIcon />
+        </MenuButton>
+        <UserButton disableFocusRipple disableRipple>
+          <PersonIcon />
+        </UserButton>
+      </UserMenuContainer>
     </Grid>
   );
 };

--- a/frontend/src/components/Header/UserMenu/UserMenu.tsx
+++ b/frontend/src/components/Header/UserMenu/UserMenu.tsx
@@ -1,10 +1,30 @@
+import { useState } from "react";
+
 import MenuIcon from "@mui/icons-material/Menu";
 import PersonIcon from "@mui/icons-material/Person";
-import { Grid } from "@mui/material";
+import { Grid, Menu, MenuItem, Button } from "@mui/material";
 
-import { MenuButton, UserButton, UserMenuContainer } from "./UserMenu.styled";
+import {
+  UserAvatar,
+  UserMenuContainer,
+  userMenuButtonStyle,
+  menuIconStyle,
+} from "./UserMenu.styled";
 
 const UserMenu = () => {
+  const [menuAnchor, setMenuAnchor] = useState<null | HTMLElement>(null);
+  const open = Boolean(menuAnchor);
+
+  const handleMenuClick = ({
+    currentTarget,
+  }: React.MouseEvent<HTMLButtonElement>) => {
+    setMenuAnchor(currentTarget);
+  };
+
+  const handleClose = () => {
+    setMenuAnchor(null);
+  };
+
   return (
     <Grid
       container
@@ -15,18 +35,41 @@ const UserMenu = () => {
       alignItems="flex-end"
     >
       <UserMenuContainer>
-        <MenuButton
-          startIcon={<MenuIcon />}
-          disableFocusRipple
-          disableRipple
-          aria-label="회원 메뉴 버튼"
-        />
-        <UserButton
-          startIcon={<PersonIcon />}
+        <Button
           disableFocusRipple
           disableRipple
           aria-label="마이페이지 버튼"
-        />
+          id="user-menu-button"
+          aria-controls={open ? "basic-menu" : undefined}
+          aria-haspopup="true"
+          aria-expanded={open ? "true" : undefined}
+          onClick={handleMenuClick}
+          sx={userMenuButtonStyle}
+        >
+          <MenuIcon sx={menuIconStyle} />
+          <UserAvatar>
+            <PersonIcon />
+          </UserAvatar>
+        </Button>
+        <Menu
+          id="user-menu"
+          anchorEl={menuAnchor}
+          open={open}
+          onClose={handleClose}
+          MenuListProps={{
+            "aria-labelledby": "user-menu-button",
+          }}
+          anchorOrigin={{
+            vertical: "bottom",
+            horizontal: "right",
+          }}
+          transformOrigin={{
+            vertical: "top",
+            horizontal: "right",
+          }}
+        >
+          <MenuItem onClick={handleClose}>로그인</MenuItem>
+        </Menu>
       </UserMenuContainer>
     </Grid>
   );

--- a/frontend/src/components/Header/UserMenu/UserMenu.tsx
+++ b/frontend/src/components/Header/UserMenu/UserMenu.tsx
@@ -1,4 +1,7 @@
-import { Button, Grid } from "@mui/material";
+import PersonIcon from "@mui/icons-material/Person";
+import { Grid } from "@mui/material";
+
+import UserButton from "./UserMenu.styled";
 
 const UserMenu = () => {
   return (
@@ -10,9 +13,14 @@ const UserMenu = () => {
       direction="column"
       alignItems="flex-end"
     >
-      <Button color="black" disableFocusRipple disableRipple>
-        메뉴
-      </Button>
+      <UserButton
+        variant="contained"
+        color="white"
+        disableFocusRipple
+        disableRipple
+      >
+        <PersonIcon />
+      </UserButton>
     </Grid>
   );
 };

--- a/frontend/src/components/Header/UserMenu/UserMenu.tsx
+++ b/frontend/src/components/Header/UserMenu/UserMenu.tsx
@@ -15,11 +15,17 @@ const UserMenu = () => {
       alignItems="flex-end"
     >
       <UserMenuContainer>
-        <MenuButton startIcon={<MenuIcon />} disableFocusRipple disableRipple />
+        <MenuButton
+          startIcon={<MenuIcon />}
+          disableFocusRipple
+          disableRipple
+          aria-label="회원 메뉴 버튼"
+        />
         <UserButton
           startIcon={<PersonIcon />}
           disableFocusRipple
           disableRipple
+          aria-label="마이페이지 버튼"
         />
       </UserMenuContainer>
     </Grid>

--- a/frontend/src/styles/theme.ts
+++ b/frontend/src/styles/theme.ts
@@ -8,20 +8,45 @@ const theme = createTheme({
     fontSize: 12,
   },
   palette: {
+    primary: {
+      main: "#E84C60",
+    },
+    secondary: {
+      main: "#118917",
+    },
     black: {
       main: "#010101",
+    },
+    white: {
+      main: "#FFF",
+    },
+    grey1: {
+      main: "#333333",
+    },
+    grey2: {
+      main: "#4F4F4F",
+    },
+    grey3: {
+      main: "#828282",
+    },
+    grey4: {
+      main: "#BDBDBD",
+    },
+    grey5: {
+      main: "#E0E0E0",
+    },
+    grey6: {
+      main: "#F5F5F7",
     },
   },
   components: {
     MuiCssBaseline: {
-      styleOverrides: `
-        a {
-          text-decoration: none;
-          color: inherit;
-          &:visited: {
-            text-decoration: none;
-          }
-          `,
+      styleOverrides: {
+        a: {
+          textDecoration: "none",
+          color: "inherit",
+        },
+      },
     },
     MuiButton: {
       styleOverrides: {
@@ -43,9 +68,23 @@ const theme = createTheme({
 declare module "@mui/material/styles" {
   interface Palette {
     black: Palette["primary"];
+    white: Palette["primary"];
+    grey1: Palette["primary"];
+    grey2: Palette["primary"];
+    grey3: Palette["primary"];
+    grey4: Palette["primary"];
+    grey5: Palette["primary"];
+    grey6: Palette["primary"];
   }
   interface PaletteOptions {
     black: PaletteOptions["primary"];
+    white: PaletteOptions["primary"];
+    grey1: PaletteOptions["primary"];
+    grey2: PaletteOptions["primary"];
+    grey3: PaletteOptions["primary"];
+    grey4: PaletteOptions["primary"];
+    grey5: PaletteOptions["primary"];
+    grey6: PaletteOptions["primary"];
   }
 }
 

--- a/frontend/src/styles/theme.ts
+++ b/frontend/src/styles/theme.ts
@@ -1,5 +1,7 @@
 import { createTheme } from "@mui/material/styles";
 
+// import { createTheme } from "@mui/material";
+
 const theme = createTheme({
   typography: {
     fontFamily: ["Noto Sans KR", "sans-serif"].join(","),
@@ -11,6 +13,16 @@ const theme = createTheme({
     },
   },
   components: {
+    MuiCssBaseline: {
+      styleOverrides: `
+        a {
+          text-decoration: none;
+          color: inherit;
+          &:visited: {
+            text-decoration: none;
+          }
+          `,
+    },
     MuiButton: {
       styleOverrides: {
         root: {

--- a/frontend/src/styles/theme.ts
+++ b/frontend/src/styles/theme.ts
@@ -106,6 +106,28 @@ const theme = createTheme({
         },
       },
     },
+    MuiMenu: {
+      styleOverrides: {
+        paper: {
+          padding: "32px",
+          minWidth: "200px",
+        },
+      },
+    },
+    MuiPaper: {
+      styleOverrides: {
+        root: {
+          minWidth: "200px",
+        },
+      },
+    },
+    MuiPopover: {
+      styleOverrides: {
+        paper: {
+          minWidth: "200px",
+        },
+      },
+    },
   },
 });
 

--- a/frontend/src/styles/theme.ts
+++ b/frontend/src/styles/theme.ts
@@ -51,6 +51,8 @@ const theme = createTheme({
         root: {
           fontWeight: "400",
           fontSize: "1rem",
+          backgroundColor: "inherit",
+          minWidth: "0",
 
           "&:hover": {
             backgroundColor: "inherit",

--- a/frontend/src/styles/theme.ts
+++ b/frontend/src/styles/theme.ts
@@ -37,9 +37,18 @@ const theme = createTheme({
       main: "#F5F5F7",
     },
   },
+  size: {
+    fullSize: "100%",
+    navBarHeight: "100px",
+  },
   components: {
     MuiCssBaseline: {
       styleOverrides: {
+        "*": {
+          margin: 0,
+          padding: 0,
+        },
+
         a: {
           textDecoration: "none",
           color: "inherit",
@@ -59,6 +68,11 @@ const theme = createTheme({
             fontWeight: "700",
             textDecoration: "underline",
           },
+
+          // 버튼 내부 icon
+          span: {
+            margin: 0,
+          },
         },
       },
     },
@@ -66,6 +80,19 @@ const theme = createTheme({
 });
 
 declare module "@mui/material/styles" {
+  interface Theme {
+    size: {
+      fullSize: string;
+      navBarHeight: string;
+    };
+  }
+  // allow configuration using `createTheme`
+  interface ThemeOptions {
+    size?: {
+      fullSize?: string;
+      navBarHeight?: string;
+    };
+  }
   interface Palette {
     black: Palette["primary"];
     white: Palette["primary"];

--- a/frontend/src/styles/theme.ts
+++ b/frontend/src/styles/theme.ts
@@ -1,7 +1,5 @@
 import { createTheme } from "@mui/material/styles";
 
-// import { createTheme } from "@mui/material";
-
 const theme = createTheme({
   typography: {
     fontFamily: ["Noto Sans KR", "sans-serif"].join(","),
@@ -55,7 +53,7 @@ const theme = createTheme({
           fontSize: "1rem",
 
           "&:hover": {
-            backgroundColor: "transparent",
+            backgroundColor: "inherit",
             fontWeight: "700",
             textDecoration: "underline",
           },
@@ -91,6 +89,7 @@ declare module "@mui/material/styles" {
 declare module "@mui/material/Button" {
   interface ButtonPropsColorOverrides {
     black: true;
+    white: true;
   }
 }
 

--- a/frontend/src/styles/theme.ts
+++ b/frontend/src/styles/theme.ts
@@ -76,6 +76,13 @@ const theme = createTheme({
         },
       },
     },
+    MuiContainer: {
+      styleOverrides: {
+        root: {
+          margin: 0,
+        },
+      },
+    },
   },
 });
 

--- a/frontend/src/styles/theme.ts
+++ b/frontend/src/styles/theme.ts
@@ -40,6 +40,24 @@ const theme = createTheme({
   size: {
     fullSize: "100%",
     navBarHeight: "100px",
+    userMenuButton: {
+      width: `32px`,
+      height: `32px`,
+    },
+  },
+  style: {
+    circularBorder: `border-radius: 50%;`,
+    alignCenter: {
+      flex: ` 
+    display:flex;
+    justify-content: center;
+    align-items: center;
+    `,
+      margin: "0 auto",
+    },
+  },
+  whiteSpace: {
+    inner: "80px",
   },
   components: {
     MuiCssBaseline: {
@@ -80,6 +98,11 @@ const theme = createTheme({
       styleOverrides: {
         root: {
           margin: 0,
+          padding: 0,
+
+          "@media (min-width: 600px)": {
+            padding: 0,
+          },
         },
       },
     },
@@ -91,13 +114,40 @@ declare module "@mui/material/styles" {
     size: {
       fullSize: string;
       navBarHeight: string;
+      userMenuButton: {
+        width: string;
+        height: string;
+      };
+    };
+    style: {
+      alignCenter: {
+        flex: string;
+        margin: string;
+      };
+      circularBorder: string;
+    };
+    whiteSpace: {
+      inner: string;
     };
   }
-  // allow configuration using `createTheme`
   interface ThemeOptions {
     size?: {
       fullSize?: string;
       navBarHeight?: string;
+      userMenuButton?: {
+        width?: string;
+        height?: string;
+      };
+    };
+    style?: {
+      alignCenter?: {
+        flex?: string;
+        margin?: string;
+      };
+      circularBorder: string;
+    };
+    whiteSpace?: {
+      inner?: string;
     };
   }
   interface Palette {

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -1578,6 +1578,13 @@
     prop-types "^15.8.1"
     react-is "^17.0.2"
 
+"@mui/icons-material@^5.8.0":
+  version "5.8.0"
+  resolved "https://registry.yarnpkg.com/@mui/icons-material/-/icons-material-5.8.0.tgz#c85768434bda885c64a8e4b9e222e73912244570"
+  integrity sha512-ScwLxa0q5VYV70Jfc60V/9VD0b9SvIeZ0Jddx2Dt2pBUFFO9vKdrbt9LYiT+4p21Au5NdYIb2XSHj46CLN1v3g==
+  dependencies:
+    "@babel/runtime" "^7.17.2"
+
 "@mui/material@^5.8.0":
   version "5.8.0"
   resolved "https://registry.yarnpkg.com/@mui/material/-/material-5.8.0.tgz#7451cecde57a24a9c407ec5122369240f5e7fae3"


### PR DESCRIPTION
## 🤷‍♂️ Description

첫 화면 Header영역 GNB, 히어로이미지 영역까지 구현

## 📝 Primary Commits

- MUI를 사용하여 Header의 GNB, 히어로이미지까지 구현
- close #8 

## 📷 Screenshots

![작업사항 확인 스크린샷](https://user-images.githubusercontent.com/78826879/170408311-33a683f6-18ba-4b9e-95f4-1249a7c9f289.png)

