### PR TITLE
[BE] 숙소 목록 조회 시 위경도 범위 계산 오류

### DIFF
--- a/backend/src/main/java/com/codesquad/airbnb/common/embeddable/Location.java
+++ b/backend/src/main/java/com/codesquad/airbnb/common/embeddable/Location.java
@@ -9,6 +9,7 @@ import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.ToString;
 import org.locationtech.jts.geom.Point;
 
 @Getter
@@ -16,6 +17,7 @@ import org.locationtech.jts.geom.Point;
 @Access(AccessType.FIELD)
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@ToString
 public class Location {
 
     private Double longitude;

--- a/backend/src/main/java/com/codesquad/airbnb/room/domain/LocationCluster.java
+++ b/backend/src/main/java/com/codesquad/airbnb/room/domain/LocationCluster.java
@@ -3,29 +3,32 @@ package com.codesquad.airbnb.room.domain;
 import com.codesquad.airbnb.common.embeddable.Location;
 import com.codesquad.airbnb.room.dto.request.RoomSearCondition.Radius;
 import lombok.AllArgsConstructor;
+import lombok.ToString;
 
 @AllArgsConstructor
+@ToString
 public class LocationCluster {
 
-    private final Location south;
     private final Location north;
+    private final Location south;
     private final Location east;
     private final Location west;
 
-    public double getMinLatitude() {
-        return south.getLatitude();
-    }
 
     public double getMaxLatitude() {
         return north.getLatitude();
     }
 
-    public double getMinLongitude() {
-        return west.getLongitude();
+    public double getMinLatitude() {
+        return south.getLatitude();
     }
 
     public double getMaxLongitude() {
         return east.getLongitude();
+    }
+
+    public double getMinLongitude() {
+        return west.getLongitude();
     }
 
     public static LocationCluster of(Location location, Radius radius) {

--- a/backend/src/main/java/com/codesquad/airbnb/room/repository/RoomRepositoryCustomImpl.java
+++ b/backend/src/main/java/com/codesquad/airbnb/room/repository/RoomRepositoryCustomImpl.java
@@ -69,9 +69,9 @@ public class RoomRepositoryCustomImpl implements RoomRepositoryCustom {
         LocationCluster locationCluster = LocationCluster.of(location, radius);
 
         return room.location.latitude.loe(locationCluster.getMaxLatitude())
-            .and(room.location.latitude.goe(locationCluster.getMinLatitude())
-                .and(room.location.longitude.loe(locationCluster.getMaxLongitude())
-                    .and(room.location.longitude.goe(locationCluster.getMinLongitude()))));
+            .and(room.location.latitude.goe(locationCluster.getMinLatitude()))
+            .and(room.location.longitude.loe(locationCluster.getMaxLongitude()))
+            .and(room.location.longitude.goe(locationCluster.getMinLongitude()));
     }
 
     private BooleanExpression guestGroupGoe(GuestGroup guestGroup) {


### PR DESCRIPTION
## 🤷‍♂️ Description

<!-- 구현하고자 하는 기능에 대해 작성해 주세요. -->

`LocationCluster` 객체 내에서 입력된 `Location` 에 따른 범위 생성 시,
생성자에 잘못된 인자 입력 순서로 인해 수정 사항이 발생했습니다.

## 📝 Primary Commits

<!-- 세부 구현 사항을 리스트로 작성해주세요. -->

- [X] `LocationCluster` 내 생성자 호출 시 인자 순서 변경

<!--마지막으로 PR 생성 시 우측의 옵션들을 체크했는지 확인해주세요!-->
