### PR TITLE
[FE] 검색결과 관련 버그

### DIFF
--- a/frontend/src/components/Header/ChildNodes.tsx
+++ b/frontend/src/components/Header/ChildNodes.tsx
@@ -12,14 +12,10 @@ import SearchBar from "./SearchBar/SearchBar";
 import UserMenu from "./UserMenu/UserMenu";
 
 const LogoArea = () => {
-  const { setIsSearchBarFullSize } = useContext(SearchBarStateContext)!;
-
   return (
     <Grid container item xs={2} justifyContent="left">
       <h1 style={{ margin: "auto 0" }}>
-        <Link to="index" onClick={() => setIsSearchBarFullSize(true)}>
-          LOGO
-        </Link>
+        <Link to="index">LOGO</Link>
       </h1>
     </Grid>
   );

--- a/frontend/src/components/Header/ChildNodes.tsx
+++ b/frontend/src/components/Header/ChildNodes.tsx
@@ -4,6 +4,7 @@ import { Grid } from "@mui/material";
 
 import { SearchBarStateContext } from "contexts/contexts";
 import MENUS from "mockData/menus";
+import RouterContext from "router/Contexts";
 import Link from "router/Link";
 
 import GNB from "./GNB/GNB";
@@ -47,7 +48,8 @@ const headerMiddleItem = {
 };
 
 const ChildNodes = () => {
-  const { isSearchBarFullSize } = useContext(SearchBarStateContext)!;
+  const { isSearchBarFullSize } = { ...useContext(SearchBarStateContext) };
+  const { page } = { ...useContext(RouterContext) };
 
   return (
     <>
@@ -58,12 +60,12 @@ const ChildNodes = () => {
         sx={{ height: ({ elementSize }) => elementSize.fullSize }}
       >
         <LogoArea />
-        {isSearchBarFullSize
+        {isSearchBarFullSize || page === "index"
           ? headerMiddleItem.fullSize
           : headerMiddleItem.miniSize}
         <UserMenu />
       </Grid>
-      {isSearchBarFullSize && <SearchBar />}
+      {(isSearchBarFullSize || page === "index") && <SearchBar />}
     </>
   );
 };

--- a/frontend/src/components/Header/Header.style.ts
+++ b/frontend/src/components/Header/Header.style.ts
@@ -1,3 +1,4 @@
+import emotionStyled from "@emotion/styled";
 import { Container, ContainerProps, Theme } from "@mui/material";
 import { styled } from "@mui/material/styles";
 
@@ -29,6 +30,13 @@ const miniHeaderWithFullSizeSearchBar = {
   height: "190px",
 };
 
+const HeaderLayer = emotionStyled.div`
+  position: absolute;
+  top: 0;
+  width: 100vw;
+  height: 100vh;
+`;
+
 const HeaderContainer = styled(Container)<ContainerProps>(
   ({ theme: { elementSize, style, whiteSpace } }) => `
   height: ${elementSize.header.others.height};
@@ -42,4 +50,5 @@ export {
   HeaderContainer,
   miniHeaderStyle,
   miniHeaderWithFullSizeSearchBar,
+  HeaderLayer,
 };

--- a/frontend/src/components/Header/Header.style.ts
+++ b/frontend/src/components/Header/Header.style.ts
@@ -21,6 +21,7 @@ const miniHeaderStyle = {
   ...defaultHeaderStyle,
   height: theme.elementSize.header.others.height,
   backgroundColor: ({ palette }: Theme) => palette.white.main,
+  boxShadow: `0px 4px 15px -3px rgba(0,0,0,0.1)`,
 };
 
 const miniHeaderWithFullSizeSearchBar = {
@@ -32,7 +33,7 @@ const HeaderContainer = styled(Container)<ContainerProps>(
   ({ theme: { elementSize, style, whiteSpace } }) => `
   height: ${elementSize.header.others.height};
   margin: ${style.alignCenter.margin};
-  padding: 0 ${whiteSpace.inner} !important;
+padding: 0 ${whiteSpace.inner} !important;
 `
 );
 

--- a/frontend/src/components/Header/Header.style.ts
+++ b/frontend/src/components/Header/Header.style.ts
@@ -21,7 +21,7 @@ const miniHeaderStyle = {
   ...defaultHeaderStyle,
   height: theme.elementSize.header.others.height,
   backgroundColor: ({ palette }: Theme) => palette.white.main,
-  boxShadow: `0px 4px 15px -3px rgba(0,0,0,0.1)`,
+  boxShadow: `0px 9px 15px -3px rgba(0,0,0,0.1)`,
 };
 
 const miniHeaderWithFullSizeSearchBar = {

--- a/frontend/src/components/Header/Header.tsx
+++ b/frontend/src/components/Header/Header.tsx
@@ -25,7 +25,11 @@ const Header = (): JSX.Element => {
   return (
     <Box
       component="header"
-      sx={isSearchBarFullSize ? fullSizeHeaderStyle : miniHeaderStyle}
+      sx={
+        isSearchBarFullSize || page === "index"
+          ? fullSizeHeaderStyle
+          : miniHeaderStyle
+      }
     >
       <HeaderContainer maxWidth="xl">
         <ChildNodes />

--- a/frontend/src/components/Header/Header.tsx
+++ b/frontend/src/components/Header/Header.tsx
@@ -3,7 +3,6 @@ import { useContext } from "react";
 import Box from "@mui/material/Box";
 
 import { SearchBarStateContext } from "contexts/contexts";
-// import { LocationContext } from "router/Contexts";
 import RouterContext from "router/Contexts";
 
 import ChildNodes from "./ChildNodes";
@@ -23,7 +22,6 @@ const Header = (): JSX.Element => {
 
   const fullSizeHeaderStyle =
     page === "index" ? indexHeaderStyle : miniHeaderWithFullSizeSearchBar;
-  // pathname === "/" ? indexHeaderStyle : miniHeaderWithFullSizeSearchBar;
 
   return (
     <Box

--- a/frontend/src/components/Header/Header.tsx
+++ b/frontend/src/components/Header/Header.tsx
@@ -12,10 +12,13 @@ import {
   HeaderContainer,
   miniHeaderStyle,
   miniHeaderWithFullSizeSearchBar,
+  HeaderLayer,
 } from "./Header.style";
 
 const Header = (): JSX.Element => {
-  const { isSearchBarFullSize } = useContext(SearchBarStateContext)!;
+  const { isSearchBarFullSize, setIsSearchBarFullSize } = useContext(
+    SearchBarStateContext
+  )!;
   const { page } = useContext(RouterContext)!;
 
   const fullSizeHeaderStyle =
@@ -31,6 +34,13 @@ const Header = (): JSX.Element => {
           : miniHeaderStyle
       }
     >
+      {page !== "index" && isSearchBarFullSize && (
+        <HeaderLayer
+          onClick={() => setIsSearchBarFullSize(false)}
+          onKeyUp={() => setIsSearchBarFullSize(false)}
+          aria-hidden
+        />
+      )}
       <HeaderContainer maxWidth="xl">
         <ChildNodes />
       </HeaderContainer>

--- a/frontend/src/components/Header/SearchBar/ModalInnerItems/ReservationFeeModal/PriceChart.tsx
+++ b/frontend/src/components/Header/SearchBar/ModalInnerItems/ReservationFeeModal/PriceChart.tsx
@@ -6,7 +6,6 @@ import theme from "styles/theme";
 import { PriceChartCanvas } from "./ReservationFeeModal.style";
 
 // TODO: 실제 API 데이터로 수정, 테마 분리
-
 const EXCLUDE_RANGE_COUNT = 1;
 
 const canvasSize = theme.elementSize.searchBar.priceChart;

--- a/frontend/src/components/Header/SearchBar/SearchBar.style.ts
+++ b/frontend/src/components/Header/SearchBar/SearchBar.style.ts
@@ -1,27 +1,19 @@
 import { Container } from "@mui/material";
 import { styled } from "@mui/material/styles";
 
-import { LinkPath } from "router";
-
 const SearchBarContainer = styled(Container, {
-  shouldForwardProp: (prop) =>
-    prop !== "isSearchBarFullSize" && prop !== "currentPage",
+  shouldForwardProp: (prop) => prop !== "isSearchBarFullSize",
   name: "MyThemeComponent",
   slot: "Root",
 })<SearchBarContainerProps>(
-  ({
-    isSearchBarFullSize,
-    currentPage,
-    theme: { elementSize, palette, style },
-  }) => {
-    const containerSize =
-      isSearchBarFullSize || currentPage === "index"
-        ? `
+  ({ isSearchBarFullSize, theme: { elementSize, palette, style } }) => {
+    const containerSize = isSearchBarFullSize
+      ? `
       max-width: ${elementSize.searchBar.fullSize.maxWidth};
       height: ${elementSize.searchBar.fullSize.height};
       padding: ${elementSize.searchBar.fullSize.padding};
       `
-        : `
+      : `
         width: ${elementSize.searchBar.miniSize.width};
         height: ${elementSize.searchBar.miniSize.height};
         padding: ${elementSize.searchBar.miniSize.padding};
@@ -58,5 +50,4 @@ export default SearchBarContainer;
 
 export interface SearchBarContainerProps {
   isSearchBarFullSize?: boolean;
-  currentPage?: LinkPath;
 }

--- a/frontend/src/components/Header/SearchBar/SearchBar.style.ts
+++ b/frontend/src/components/Header/SearchBar/SearchBar.style.ts
@@ -1,19 +1,27 @@
 import { Container } from "@mui/material";
 import { styled } from "@mui/material/styles";
 
+import { LinkPath } from "router";
+
 const SearchBarContainer = styled(Container, {
-  shouldForwardProp: (prop) => prop !== "isSearchBarFullSize",
+  shouldForwardProp: (prop) =>
+    prop !== "isSearchBarFullSize" && prop !== "currentPage",
   name: "MyThemeComponent",
   slot: "Root",
 })<SearchBarContainerProps>(
-  ({ isSearchBarFullSize, theme: { elementSize, palette, style } }) => {
-    const containerSize = isSearchBarFullSize
-      ? `
+  ({
+    isSearchBarFullSize,
+    currentPage,
+    theme: { elementSize, palette, style },
+  }) => {
+    const containerSize =
+      isSearchBarFullSize || currentPage === "index"
+        ? `
       max-width: ${elementSize.searchBar.fullSize.maxWidth};
       height: ${elementSize.searchBar.fullSize.height};
       padding: ${elementSize.searchBar.fullSize.padding};
       `
-      : `
+        : `
         width: ${elementSize.searchBar.miniSize.width};
         height: ${elementSize.searchBar.miniSize.height};
         padding: ${elementSize.searchBar.miniSize.padding};
@@ -50,5 +58,5 @@ export default SearchBarContainer;
 
 export interface SearchBarContainerProps {
   isSearchBarFullSize?: boolean;
-  // isSearchBarFullSize?: React.MutableRefObject<boolean>;
+  currentPage?: LinkPath;
 }

--- a/frontend/src/components/Header/SearchBar/SearchBar.tsx
+++ b/frontend/src/components/Header/SearchBar/SearchBar.tsx
@@ -19,8 +19,7 @@ const SearchBar = (): JSX.Element => {
 
   return (
     <SearchBarContainer
-      isSearchBarFullSize={isSearchBarFullSize}
-      currentPage={page}
+      isSearchBarFullSize={isSearchBarFullSize || page === "index"}
     >
       <SelectItemArea />
     </SearchBarContainer>

--- a/frontend/src/components/Header/SearchBar/SearchBar.tsx
+++ b/frontend/src/components/Header/SearchBar/SearchBar.tsx
@@ -1,6 +1,7 @@
 import { useContext } from "react";
 
 import { SearchBarStateContext } from "contexts/contexts";
+import RouterContext from "router/Contexts";
 
 import SearchBarContainer from "./SearchBar.style";
 import SelectItemArea from "./SelectItemArea/SelectItemArea";
@@ -13,10 +14,14 @@ const SearchBar = (): JSX.Element => {
   // 이렇게 하지 않으면 검색결과화면에서 뒤로가기 버튼으로 첫 화면으로 이동하였을때에도 SearchBar에 현재 선택한 사항이 유지됨
   // (실제 에어비앤비는 같은 방법으로 초기화면으로 돌아간 경우 SearchBar가 초기화되어 표시된다. 👉 이렇게 표시하기 위해)
 
-  const { isSearchBarFullSize } = useContext(SearchBarStateContext)!;
+  const { isSearchBarFullSize } = { ...useContext(SearchBarStateContext) };
+  const { page } = { ...useContext(RouterContext) };
 
   return (
-    <SearchBarContainer isSearchBarFullSize={isSearchBarFullSize}>
+    <SearchBarContainer
+      isSearchBarFullSize={isSearchBarFullSize}
+      currentPage={page}
+    >
       <SelectItemArea />
     </SearchBarContainer>
   );

--- a/frontend/src/components/Header/SearchBar/SearchBar.tsx
+++ b/frontend/src/components/Header/SearchBar/SearchBar.tsx
@@ -7,13 +7,6 @@ import SearchBarContainer from "./SearchBar.style";
 import SelectItemArea from "./SelectItemArea/SelectItemArea";
 
 const SearchBar = (): JSX.Element => {
-  // TODO:
-  // 첫 화면, 검색결과 화면 모두 같은 SearchBar를 공유함
-  // 검색하기 위해서 SelectItem들을 선택할때는 해당 SelectItemArea의 state로 저장되지만
-  // 검색버튼을 눌러 이동된 후에는 주소창의 쿼리문을 통해 현재 검색했던 내용을 불러와야함.
-  // 이렇게 하지 않으면 검색결과화면에서 뒤로가기 버튼으로 첫 화면으로 이동하였을때에도 SearchBar에 현재 선택한 사항이 유지됨
-  // (실제 에어비앤비는 같은 방법으로 초기화면으로 돌아간 경우 SearchBar가 초기화되어 표시된다. 👉 이렇게 표시하기 위해)
-
   const { isSearchBarFullSize } = { ...useContext(SearchBarStateContext) };
   const { page } = { ...useContext(RouterContext) };
 

--- a/frontend/src/components/Header/SearchBar/SelectItemArea/ButtonArea/ButtonArea.tsx
+++ b/frontend/src/components/Header/SearchBar/SelectItemArea/ButtonArea/ButtonArea.tsx
@@ -4,6 +4,7 @@ import CloseIcon from "@mui/icons-material/Close";
 import SearchIcon from "@mui/icons-material/Search";
 
 import { SearchBarStateContext } from "contexts/contexts";
+import RouterContext from "router/Contexts";
 
 import { SelectItemTemplate } from "../SelectItemTemplate/SelectItemTemplate";
 import RoundButton, { RoundButtonProps } from "./ButtonArea.style";
@@ -22,6 +23,7 @@ const ButtonArea = ({
   xs = 1,
 }: ButtonAreaProps): JSX.Element => {
   const { isSearchBarFullSize } = useContext(SearchBarStateContext)!;
+  const { page } = useContext(RouterContext)!;
 
   return (
     <SelectItemTemplate
@@ -37,7 +39,7 @@ const ButtonArea = ({
         isFocused={isFocused}
         onClick={onClick}
         aria-label={ariaLabel}
-        isSearchBarFullSize={isSearchBarFullSize}
+        isSearchBarFullSize={isSearchBarFullSize || page === "index"}
       >
         {icons[icon]}
         {isFocused && "검색"}

--- a/frontend/src/components/Header/SearchBar/SelectItemArea/SelectItem/CheckInOut.tsx
+++ b/frontend/src/components/Header/SearchBar/SelectItemArea/SelectItem/CheckInOut.tsx
@@ -3,6 +3,7 @@ import { useContext, useRef } from "react";
 import { Grid } from "@mui/material";
 
 import { SearchBarStateContext } from "contexts/contexts";
+import RouterContext from "router/Contexts";
 
 import ButtonArea from "../ButtonArea/ButtonArea";
 import { ModalTemplate } from "../SelectItemTemplate/SelectItemTemplate";
@@ -18,6 +19,7 @@ const CheckInOut = ({
   const { isSearchBarFullSize, setIsSearchBarFullSize } = useContext(
     SearchBarStateContext
   )!;
+  const { page } = { ...useContext(RouterContext) };
 
   const $wrap = useRef<HTMLDivElement>(null);
   const isOpen = anchorEl?.id === wrapperId;
@@ -30,12 +32,12 @@ const CheckInOut = ({
     <Grid
       item
       container
-      xs={isSearchBarFullSize ? 5 : 3}
+      xs={isSearchBarFullSize || page === "index" ? 5 : 3}
       component="div"
       id={wrapperId}
       ref={$wrap}
     >
-      {(isSearchBarFullSize && (
+      {((isSearchBarFullSize || page === "index") && (
         <>
           <SelectItem
             gridStyle={{

--- a/frontend/src/components/Header/SearchBar/SelectItemArea/SelectItem/PeopleCount.tsx
+++ b/frontend/src/components/Header/SearchBar/SelectItemArea/SelectItem/PeopleCount.tsx
@@ -1,6 +1,7 @@
 import { useContext } from "react";
 
 import { SearchBarStateContext } from "contexts/contexts";
+import RouterContext from "router/Contexts";
 
 import ButtonArea from "../ButtonArea/ButtonArea";
 import SelectItem, { SelectItemProps, WhiteSpace } from "./SelectItem";
@@ -15,6 +16,7 @@ const PeopleCount = ({
   const { isSearchBarFullSize, setIsSearchBarFullSize } = useContext(
     SearchBarStateContext
   )!;
+  const { page } = { ...useContext(RouterContext) };
 
   const isOpen = anchorEl?.id === buttonId;
 
@@ -22,7 +24,7 @@ const PeopleCount = ({
     <>
       <SelectItem
         gridStyle={
-          isSearchBarFullSize
+          isSearchBarFullSize || page === "index"
             ? {
                 xs: 2,
                 pl: 2,

--- a/frontend/src/components/Header/SearchBar/SelectItemArea/SelectItem/PeopleCount.tsx
+++ b/frontend/src/components/Header/SearchBar/SelectItemArea/SelectItem/PeopleCount.tsx
@@ -37,10 +37,12 @@ const PeopleCount = ({
         buttonId={buttonId}
         buttonAreaLabel="숙박 인원 설정"
         title="인원"
-        desc={isSearchBarFullSize ? "게스트 추가" : "인원 입력"}
+        desc={
+          isSearchBarFullSize || page === "index" ? "게스트 추가" : "인원 입력"
+        }
         open={isOpen}
         handleClick={
-          isSearchBarFullSize
+          isSearchBarFullSize || page === "index"
             ? onClick
             : () => {
                 setIsSearchBarFullSize(true);

--- a/frontend/src/components/Header/SearchBar/SelectItemArea/SelectItem/PeopleCount.tsx
+++ b/frontend/src/components/Header/SearchBar/SelectItemArea/SelectItem/PeopleCount.tsx
@@ -46,7 +46,7 @@ const PeopleCount = ({
             ? onClick
             : () => {
                 setIsSearchBarFullSize(true);
-                // peoplecount모달도 open상태로 되면 좋음.
+                // NOTE: peoplecount모달도 open상태로 되면 좋음.
               }
         }
         anchorEl={anchorEl}

--- a/frontend/src/components/Header/SearchBar/SelectItemArea/SelectItem/ReservationFee.tsx
+++ b/frontend/src/components/Header/SearchBar/SelectItemArea/SelectItem/ReservationFee.tsx
@@ -34,7 +34,7 @@ const ReservationFee = ({
   // const { queryData } = { ...useContext(LocationContext) };
   // const { queryData } = { ...useContext(LocationContext) };
 
-  const { queryData } = { ...useContext(RouterContext) };
+  const { queryData, page } = { ...useContext(RouterContext) };
 
   // const { state: params } = window.history;
   // const { search } = window.location;
@@ -79,7 +79,7 @@ const ReservationFee = ({
     >
       <SelectItem
         gridStyle={
-          isSearchBarFullSize
+          isSearchBarFullSize || page === "index"
             ? {
                 xs: 2,
                 pl: 2,

--- a/frontend/src/components/Header/SearchBar/SelectItemArea/SelectItem/ReservationFee.tsx
+++ b/frontend/src/components/Header/SearchBar/SelectItemArea/SelectItem/ReservationFee.tsx
@@ -92,7 +92,7 @@ const ReservationFee = ({
         desc={description}
         open={isOpen}
         handleClick={
-          isSearchBarFullSize
+          isSearchBarFullSize || page === "index"
             ? onClick
             : () => {
                 setIsSearchBarFullSize(true);

--- a/frontend/src/components/Header/SearchBar/SelectItemArea/SelectItem/ReservationFee.tsx
+++ b/frontend/src/components/Header/SearchBar/SelectItemArea/SelectItem/ReservationFee.tsx
@@ -1,7 +1,6 @@
 import { useState, useContext, useMemo } from "react";
 
 import { PriceRangeContext, SearchBarStateContext } from "contexts/contexts";
-// import { LocationContext } from "router/Contexts";
 import RouterContext from "router/Contexts";
 import numToWon from "utils/utils";
 
@@ -27,18 +26,7 @@ const ReservationFee = ({
   stateData,
   initialPrice,
 }: ReservationFeeProps): JSX.Element => {
-  const { state: price, setState: setPrice } = stateData as {
-    state: RangeType;
-    setState: React.Dispatch<React.SetStateAction<RangeType>>;
-  };
-  // const { queryData } = { ...useContext(LocationContext) };
-  // const { queryData } = { ...useContext(LocationContext) };
-
   const { queryData, page } = { ...useContext(RouterContext) };
-
-  // const { state: params } = window.history;
-  // const { search } = window.location;
-
   const { isSearchBarFullSize, setIsSearchBarFullSize } = useContext(
     SearchBarStateContext
   )!;
@@ -48,9 +36,12 @@ const ReservationFee = ({
     max: INITIAL_PRICE_PERCENTAGE.max,
   });
 
+  const { state: price, setState: setPrice } = stateData as {
+    state: RangeType;
+    setState: React.Dispatch<React.SetStateAction<RangeType>>;
+  };
   const isQueryDataIncludesPriceRange =
     queryData?.minPrice || queryData?.maxPrice;
-  // const isQueryDataIncludesPriceRange = true;
 
   const description =
     !isQueryDataIncludesPriceRange &&
@@ -96,7 +87,7 @@ const ReservationFee = ({
             ? onClick
             : () => {
                 setIsSearchBarFullSize(true);
-                // reservationFee모달도 open상태로 되면 좋음.
+                // NOTE: reservationFee모달도 open상태로 되면 좋음.
               }
         }
         handleClose={onClose}

--- a/frontend/src/components/Header/SearchBar/SelectItemArea/SelectItem/SelectItem.tsx
+++ b/frontend/src/components/Header/SearchBar/SelectItemArea/SelectItem/SelectItem.tsx
@@ -10,7 +10,6 @@ import {
 
 import { SearchBarStateContext } from "contexts/contexts";
 import RouterContext from "router/Contexts";
-// import { LocationContext } from "router/Contexts";
 
 import {
   ModalTemplate,
@@ -35,10 +34,6 @@ const SelectItem = ({ ...props }: SelectItemDataProps): JSX.Element => {
     createNewPopup,
   } = props;
 
-  // const { queryData } = useContext(LocationContext)!;
-  // const { state: params } = window.history;
-
-  // const { queryData, page } = { ...useContext(RouterContext) };
   const { isSearchBarFullSize } = { ...useContext(SearchBarStateContext) };
   const { page } = { ...useContext(RouterContext) };
 
@@ -57,7 +52,6 @@ const SelectItem = ({ ...props }: SelectItemDataProps): JSX.Element => {
           <Typography sx={itemStyles.title}>{title}</Typography>
         )}
         {/* 쿼리데이터가 없는 경우 표시 */}
-
         <Typography
           sx={
             isSearchBarFullSize || page === "index"

--- a/frontend/src/components/Header/SearchBar/SelectItemArea/SelectItem/SelectItem.tsx
+++ b/frontend/src/components/Header/SearchBar/SelectItemArea/SelectItem/SelectItem.tsx
@@ -9,7 +9,7 @@ import {
 } from "@mui/material";
 
 import { SearchBarStateContext } from "contexts/contexts";
-import RouterContext from "router/Contexts";
+// import RouterContext from "router/Contexts";
 // import { LocationContext } from "router/Contexts";
 
 import {
@@ -38,7 +38,7 @@ const SelectItem = ({ ...props }: SelectItemDataProps): JSX.Element => {
   // const { queryData } = useContext(LocationContext)!;
   // const { state: params } = window.history;
 
-  const { queryData } = { ...useContext(RouterContext) };
+  // const { queryData, page } = { ...useContext(RouterContext) };
   const { isSearchBarFullSize } = { ...useContext(SearchBarStateContext) };
 
   return (
@@ -56,13 +56,12 @@ const SelectItem = ({ ...props }: SelectItemDataProps): JSX.Element => {
           <Typography sx={itemStyles.title}>{title}</Typography>
         )}
         {/* 쿼리데이터가 없는 경우 표시 */}
-        {!queryData && (
-          <Typography
-            sx={isSearchBarFullSize ? itemStyles.desc : itemStyles.miniSizeDesc}
-          >
-            {desc}
-          </Typography>
-        )}
+
+        <Typography
+          sx={isSearchBarFullSize ? itemStyles.desc : itemStyles.miniSizeDesc}
+        >
+          {desc}
+        </Typography>
       </Button>
       {(createNewPopup && (
         <ModalTemplate

--- a/frontend/src/components/Header/SearchBar/SelectItemArea/SelectItem/SelectItem.tsx
+++ b/frontend/src/components/Header/SearchBar/SelectItemArea/SelectItem/SelectItem.tsx
@@ -9,7 +9,7 @@ import {
 } from "@mui/material";
 
 import { SearchBarStateContext } from "contexts/contexts";
-// import RouterContext from "router/Contexts";
+import RouterContext from "router/Contexts";
 // import { LocationContext } from "router/Contexts";
 
 import {
@@ -40,6 +40,7 @@ const SelectItem = ({ ...props }: SelectItemDataProps): JSX.Element => {
 
   // const { queryData, page } = { ...useContext(RouterContext) };
   const { isSearchBarFullSize } = { ...useContext(SearchBarStateContext) };
+  const { page } = { ...useContext(RouterContext) };
 
   return (
     <SelectItemTemplate xs={xs} pl={pl}>
@@ -52,13 +53,17 @@ const SelectItem = ({ ...props }: SelectItemDataProps): JSX.Element => {
         onClick={handleClick}
         sx={itemStyles.button}
       >
-        {isSearchBarFullSize && (
+        {(isSearchBarFullSize || page === "index") && (
           <Typography sx={itemStyles.title}>{title}</Typography>
         )}
         {/* 쿼리데이터가 없는 경우 표시 */}
 
         <Typography
-          sx={isSearchBarFullSize ? itemStyles.desc : itemStyles.miniSizeDesc}
+          sx={
+            isSearchBarFullSize || page === "index"
+              ? itemStyles.desc
+              : itemStyles.miniSizeDesc
+          }
         >
           {desc}
         </Typography>

--- a/frontend/src/components/Header/SearchBar/SelectItemArea/SelectItemArea.tsx
+++ b/frontend/src/components/Header/SearchBar/SelectItemArea/SelectItemArea.tsx
@@ -3,6 +3,7 @@ import { useContext, useState } from "react";
 import { Grid } from "@mui/material";
 
 import { SearchBarStateContext } from "contexts/contexts";
+import RouterContext from "router/Contexts";
 import Link from "router/Link";
 
 import ButtonArea from "./ButtonArea/ButtonArea";
@@ -26,6 +27,7 @@ const SelectItemArea = (): JSX.Element => {
   const { isSearchBarFullSize, setIsSearchBarFullSize } = useContext(
     SearchBarStateContext
   )!;
+  const { page } = { ...useContext(RouterContext) };
 
   const [anchorEl, setAnchorEl] = useState<AnchorEl>(null);
   const [price, setPrice] = useState({
@@ -72,7 +74,7 @@ const SelectItemArea = (): JSX.Element => {
         <Link
           to="searchResult"
           onClick={
-            isSearchBarFullSize
+            isSearchBarFullSize || page === "index"
               ? handleFullSizeSearchBarClick
               : handleMiniSearchBarClick
           }

--- a/frontend/src/components/Header/SearchBar/SelectItemArea/SelectItemArea.tsx
+++ b/frontend/src/components/Header/SearchBar/SelectItemArea/SelectItemArea.tsx
@@ -79,7 +79,7 @@ const SelectItemArea = (): JSX.Element => {
               : handleMiniSearchBarClick
           }
           query={{
-            hi: "hello",
+            test: "test1", // 쿼리 테스트용
           }}
         >
           <ButtonArea

--- a/frontend/src/components/Main/SearchResult/AccomodationsList/Filter/Filter.tsx
+++ b/frontend/src/components/Main/SearchResult/AccomodationsList/Filter/Filter.tsx
@@ -1,6 +1,7 @@
 import { useContext } from "react";
 
 import RouterContext from "router/Contexts";
+import numToWon from "utils/utils";
 
 import Item from "./Item";
 
@@ -30,15 +31,15 @@ const getDataListFromQueryData = (data: { [key: string]: string }) => {
   }
 
   if (data.minPrice) {
-    let priceRange = `${Number(data.minPrice).toLocaleString()} ~`;
+    let priceRange = `${numToWon(Number(data.minPrice))} ~`;
     if (data.maxPrice) {
-      priceRange += ` ${Number(data.maxPrice).toLocaleString()}`;
+      priceRange += ` ${numToWon(Number(data.maxPrice))}`;
     }
     result.push(["priceRange", priceRange]);
   }
 
   if (!data.minPrice && data.maxPrice) {
-    const priceRange = `${Number(data.maxPrice).toLocaleString} 까지`;
+    const priceRange = `${numToWon(Number(data.maxPrice))} 까지`;
     result.push(["priceRange", priceRange]);
   }
 

--- a/frontend/src/components/Main/SearchResult/AccomodationsList/Filter/Filter.tsx
+++ b/frontend/src/components/Main/SearchResult/AccomodationsList/Filter/Filter.tsx
@@ -5,8 +5,7 @@ import numToWon from "utils/utils";
 
 import Item from "./Item";
 
-// count: 0, // 숙소 개수. <-- 결과에서 가져와야함. length로?
-
+// NOTE: count: 0, // 숙소 개수. <-- 결과에서 가져와야함. length로?
 const getDataListFromQueryData = (data: { [key: string]: string }) => {
   const result = [];
   if (data.NumAdult || data.numChild) {
@@ -47,15 +46,13 @@ const getDataListFromQueryData = (data: { [key: string]: string }) => {
 };
 
 const Filter = () => {
-  // const { queryData } = useContext(LocationContext)!;
-  // const { state: params } = window.history;
 
   const { queryData } = { ...useContext(RouterContext) };
 
   return (
     queryData && (
       <Item
-        // count={count} // api응답으로 온 데이터
+        // count={count} // NOTE: api응답으로 온 데이터
         queryDataList={getDataListFromQueryData(queryData)}
       />
     )

--- a/frontend/src/components/Main/SearchResult/AccomodationsList/ListItemCard/ListItemCard.tsx
+++ b/frontend/src/components/Main/SearchResult/AccomodationsList/ListItemCard/ListItemCard.tsx
@@ -1,3 +1,5 @@
+import numToWon from "utils/utils";
+
 const ListItemCard = ({
   name,
   address,
@@ -42,14 +44,14 @@ const ListItemCard = ({
           <div className="info-wish-button">🧡</div>
         </div>
         <div className="info-price-wrap">
-          <p className="info-price">₩{Number(price).toLocaleString()} / 박</p>
+          <p className="info-price">₩{numToWon(Number(price))} / 박</p>
           <div className="info-review-total-area">
             <div className="info-review item">
               ⭐ {reviewScore}
               <span className="info-review-count">(후기 {reviewCount}개)</span>
             </div>
             <div className="info-total-price item">
-              ₩{Number(price).toLocaleString()}
+              ₩{numToWon(Number(price))}
             </div>
           </div>
         </div>

--- a/frontend/src/components/Main/SearchResult/MapArea/MapArea.tsx
+++ b/frontend/src/components/Main/SearchResult/MapArea/MapArea.tsx
@@ -14,8 +14,8 @@ const MapArea = () => {
   useEffect(() => {
     const mapContainer = $mapArea.current;
 
+    // TODO: new Lint오류로 임시로 ref이용, 추후 개선
     map.current = new kakao.maps.Map(mapContainer, mapOption);
-    // console.log(map);
   }, []);
 
   return <div className="map-area" ref={$mapArea} />;

--- a/frontend/src/components/Main/SearchResult/SearchResult.style.ts
+++ b/frontend/src/components/Main/SearchResult/SearchResult.style.ts
@@ -1,16 +1,20 @@
-import styled from "@emotion/styled";
+import { Container, ContainerProps } from "@mui/material";
+import { styled } from "@mui/material/styles";
 
-import theme from "styles/theme";
-
-const Wrapper = styled.div`
+const Wrapper = styled(Container)<ContainerProps>(
+  ({ theme: { elementSize, whiteSpace } }) => `
   display: flex;
   position: absolute;
   z-index: -1;
-  top: ${theme.elementSize.header.others.height};
+  top: ${elementSize.header.others.height};
+  left : 50%;
+  transform: translateX(-50%);
   width: 100%;
   height: calc(
-    100vh - ${parseInt(theme.elementSize.header.others.height, 10)}px
+    100vh - ${parseInt(elementSize.header.others.height, 10)}px
   );
+  padding:  0 ${whiteSpace.inner} !important;
+
   .map-area {
     background-color: #999;
     flex: 55;
@@ -18,7 +22,7 @@ const Wrapper = styled.div`
 
   .accomodations-list-area {
     flex: 45;
-    padding: 32px 24px;
+    padding: 12px 24px 0 0;
 
     .title {
       font-size: 24px;
@@ -29,7 +33,7 @@ const Wrapper = styled.div`
 
   .accomodations-list {
     height: calc(
-      100vh - ${theme.elementSize.header.others.height} - (32 * 2) px
+      100vh - ${elementSize.header.others.height} - (32 * 2) px
     );
     overflow-y: auto;
   }
@@ -97,6 +101,7 @@ const Wrapper = styled.div`
       text-decoration: underline;
     }
   }
-`;
+`
+);
 
 export default Wrapper;

--- a/frontend/src/components/Main/SearchResult/SearchResult.tsx
+++ b/frontend/src/components/Main/SearchResult/SearchResult.tsx
@@ -1,5 +1,7 @@
 import { useContext } from "react";
 
+import { Box } from "@mui/material";
+
 import NotFound from "components/NotFound/NotFound";
 import RouterContext from "router/Contexts";
 
@@ -17,65 +19,67 @@ const SearchResult = (): JSX.Element => {
   // console.log("확인", Object.entries(params));
 
   return (
-    <Wrapper>
-      {(queryData && (
-        <>
-          <div className="accomodations-list-area">
-            {queryData && <Filter />}
-            <h2 className="title">지도에서 선택한 지역의 숙소</h2>
-            <ul className="accomodations-list">
-              {[
-                {
-                  name: "Spacious and Comfortable cozy house #4",
-                  address: "서울특별시",
-                  imagePath: "https://bit.ly/39ZouHy",
-                  type: "WHOLE_RESIDENCE",
-                  price: 71466,
-                  longitude: 127.0286,
-                  latitude: 37.4953,
-                  reviewScore: 4.8,
-                  reviewCount: 127,
-                  numberAdult: 2,
-                  numberChild: 1,
-                  numberInfant: 0,
-                  numberBed: 1,
-                  numberBathroom: 1,
-                  kitchen: true,
-                  hairDryer: true,
-                  wirelessInternet: true,
-                  airConditioner: true,
-                  id: 1,
-                },
-                {
-                  name: "Spacious and Comfortable cozy house #4",
-                  address: "서울특별시",
-                  imagePath: "https://bit.ly/39ZouHy",
-                  type: "WHOLE_RESIDENCE",
-                  price: 71466,
-                  longitude: 127.0286,
-                  latitude: 37.4953,
-                  reviewScore: 4.8,
-                  reviewCount: 127,
-                  numberAdult: 2,
-                  numberChild: 1,
-                  numberInfant: 0,
-                  numberBed: 1,
-                  numberBathroom: 1,
-                  kitchen: true,
-                  hairDryer: true,
-                  wirelessInternet: true,
-                  airConditioner: true,
-                  id: 2,
-                },
-              ].map(({ id, ...props }) => (
-                <ListItemCard key={id} {...props} />
-              ))}
-            </ul>
-          </div>
-          <MapArea />
-        </>
-      )) || <NotFound />}
-    </Wrapper>
+    <Box component="main">
+      <Wrapper maxWidth="xl">
+        {(queryData && (
+          <>
+            <div className="accomodations-list-area">
+              {queryData && <Filter />}
+              <h2 className="title">지도에서 선택한 지역의 숙소</h2>
+              <ul className="accomodations-list">
+                {[
+                  {
+                    name: "Spacious and Comfortable cozy house #4",
+                    address: "서울특별시",
+                    imagePath: "https://bit.ly/39ZouHy",
+                    type: "WHOLE_RESIDENCE",
+                    price: 71466,
+                    longitude: 127.0286,
+                    latitude: 37.4953,
+                    reviewScore: 4.8,
+                    reviewCount: 127,
+                    numberAdult: 2,
+                    numberChild: 1,
+                    numberInfant: 0,
+                    numberBed: 1,
+                    numberBathroom: 1,
+                    kitchen: true,
+                    hairDryer: true,
+                    wirelessInternet: true,
+                    airConditioner: true,
+                    id: 1,
+                  },
+                  {
+                    name: "Spacious and Comfortable cozy house #4",
+                    address: "서울특별시",
+                    imagePath: "https://bit.ly/39ZouHy",
+                    type: "WHOLE_RESIDENCE",
+                    price: 71466,
+                    longitude: 127.0286,
+                    latitude: 37.4953,
+                    reviewScore: 4.8,
+                    reviewCount: 127,
+                    numberAdult: 2,
+                    numberChild: 1,
+                    numberInfant: 0,
+                    numberBed: 1,
+                    numberBathroom: 1,
+                    kitchen: true,
+                    hairDryer: true,
+                    wirelessInternet: true,
+                    airConditioner: true,
+                    id: 2,
+                  },
+                ].map(({ id, ...props }) => (
+                  <ListItemCard key={id} {...props} />
+                ))}
+              </ul>
+            </div>
+            <MapArea />
+          </>
+        )) || <NotFound />}
+      </Wrapper>
+    </Box>
   );
 };
 

--- a/frontend/src/components/Main/SearchResult/SearchResult.tsx
+++ b/frontend/src/components/Main/SearchResult/SearchResult.tsx
@@ -67,8 +67,8 @@ const SearchResult = (): JSX.Element => {
                   airConditioner: true,
                   id: 2,
                 },
-              ].map((el) => (
-                <ListItemCard {...el} />
+              ].map(({ id, ...props }) => (
+                <ListItemCard key={id} {...props} />
               ))}
             </ul>
           </div>

--- a/frontend/src/components/Main/SearchResult/SearchResult.tsx
+++ b/frontend/src/components/Main/SearchResult/SearchResult.tsx
@@ -11,12 +11,7 @@ import MapArea from "./MapArea/MapArea";
 import Wrapper from "./SearchResult.style";
 
 const SearchResult = (): JSX.Element => {
-  // const { queryData } = useContext(LocationContext)!;
-  // const { state: params } = window.history;
-
   const { queryData } = { ...useContext(RouterContext) };
-
-  // console.log("확인", Object.entries(params));
 
   return (
     <Box component="main">
@@ -27,52 +22,55 @@ const SearchResult = (): JSX.Element => {
               {queryData && <Filter />}
               <h2 className="title">지도에서 선택한 지역의 숙소</h2>
               <ul className="accomodations-list">
-                {[
-                  {
-                    name: "Spacious and Comfortable cozy house #4",
-                    address: "서울특별시",
-                    imagePath: "https://bit.ly/39ZouHy",
-                    type: "WHOLE_RESIDENCE",
-                    price: 71466,
-                    longitude: 127.0286,
-                    latitude: 37.4953,
-                    reviewScore: 4.8,
-                    reviewCount: 127,
-                    numberAdult: 2,
-                    numberChild: 1,
-                    numberInfant: 0,
-                    numberBed: 1,
-                    numberBathroom: 1,
-                    kitchen: true,
-                    hairDryer: true,
-                    wirelessInternet: true,
-                    airConditioner: true,
-                    id: 1,
-                  },
-                  {
-                    name: "Spacious and Comfortable cozy house #4",
-                    address: "서울특별시",
-                    imagePath: "https://bit.ly/39ZouHy",
-                    type: "WHOLE_RESIDENCE",
-                    price: 71466,
-                    longitude: 127.0286,
-                    latitude: 37.4953,
-                    reviewScore: 4.8,
-                    reviewCount: 127,
-                    numberAdult: 2,
-                    numberChild: 1,
-                    numberInfant: 0,
-                    numberBed: 1,
-                    numberBathroom: 1,
-                    kitchen: true,
-                    hairDryer: true,
-                    wirelessInternet: true,
-                    airConditioner: true,
-                    id: 2,
-                  },
-                ].map(({ id, ...props }) => (
-                  <ListItemCard key={id} {...props} />
-                ))}
+                {
+                  // 임시 데이터
+                  [
+                    {
+                      name: "Spacious and Comfortable cozy house #4",
+                      address: "서울특별시",
+                      imagePath: "https://bit.ly/39ZouHy",
+                      type: "WHOLE_RESIDENCE",
+                      price: 71466,
+                      longitude: 127.0286,
+                      latitude: 37.4953,
+                      reviewScore: 4.8,
+                      reviewCount: 127,
+                      numberAdult: 2,
+                      numberChild: 1,
+                      numberInfant: 0,
+                      numberBed: 1,
+                      numberBathroom: 1,
+                      kitchen: true,
+                      hairDryer: true,
+                      wirelessInternet: true,
+                      airConditioner: true,
+                      id: 1,
+                    },
+                    {
+                      name: "Spacious and Comfortable cozy house #4",
+                      address: "서울특별시",
+                      imagePath: "https://bit.ly/39ZouHy",
+                      type: "WHOLE_RESIDENCE",
+                      price: 71466,
+                      longitude: 127.0286,
+                      latitude: 37.4953,
+                      reviewScore: 4.8,
+                      reviewCount: 127,
+                      numberAdult: 2,
+                      numberChild: 1,
+                      numberInfant: 0,
+                      numberBed: 1,
+                      numberBathroom: 1,
+                      kitchen: true,
+                      hairDryer: true,
+                      wirelessInternet: true,
+                      airConditioner: true,
+                      id: 2,
+                    },
+                  ].map(({ id, ...props }) => (
+                    <ListItemCard key={id} {...props} />
+                  ))
+                }
               </ul>
             </div>
             <MapArea />

--- a/frontend/src/components/NotFound/NotFound.tsx
+++ b/frontend/src/components/NotFound/NotFound.tsx
@@ -1,5 +1,17 @@
 const NotFound = (): JSX.Element => {
-  return <div>비정상적인 접근입니다.</div>;
+  return (
+    <div
+      style={{
+        textAlign: "center",
+        width: "100%",
+        margin: "auto 0",
+        fontSize: "1.5rem",
+        fontWeight: "700",
+      }}
+    >
+      비정상적인 접근입니다.😦
+    </div>
+  );
 };
 
 export default NotFound;

--- a/frontend/src/contexts/SearchBar.tsx
+++ b/frontend/src/contexts/SearchBar.tsx
@@ -3,7 +3,7 @@ import { useState, useMemo } from "react";
 import { SearchBarStateContext } from "./contexts";
 
 const SearchBarContext = ({ children }: { children: React.ReactNode }) => {
-  const [isSearchBarFullSize, setIsSearchBarFullSize] = useState(true);
+  const [isSearchBarFullSize, setIsSearchBarFullSize] = useState(false);
 
   return (
     <SearchBarStateContext.Provider

--- a/frontend/src/contexts/contexts.ts
+++ b/frontend/src/contexts/contexts.ts
@@ -27,7 +27,6 @@ interface PriceRangeContextType {
 }
 
 interface SearchBarStateContextType {
-  // isSearchBarFullSize: React.MutableRefObject<boolean>;
   isSearchBarFullSize: boolean;
   setIsSearchBarFullSize: React.Dispatch<React.SetStateAction<boolean>>;
 }

--- a/frontend/src/index.tsx
+++ b/frontend/src/index.tsx
@@ -2,8 +2,6 @@ import React from "react";
 
 import ReactDOM from "react-dom/client";
 
-// import Router from "router/router";
-
 import App from "./App";
 
 const root = ReactDOM.createRoot(
@@ -11,8 +9,6 @@ const root = ReactDOM.createRoot(
 );
 root.render(
   <React.StrictMode>
-    {/* <Router> */}
     <App />
-    {/* </Router> */}
   </React.StrictMode>
 );

--- a/frontend/src/router/Contexts.ts
+++ b/frontend/src/router/Contexts.ts
@@ -9,5 +9,3 @@ const RouterContext = createContext<RouterContextType>({
 });
 
 export default RouterContext;
-
-// export const LocationContext = createContext<LocationContextType | null>(null);

--- a/frontend/src/router/Link.tsx
+++ b/frontend/src/router/Link.tsx
@@ -17,7 +17,7 @@ const queryDataToUrlString = (query: { [key: string]: string }) => {
 };
 
 const pushHistory = ({ path, state, query }: PushHistoryProps): void => {
-  // history.pushState(state, title, url);
+  // NOTE: history.pushState(state, title, url);
   const url = `${location.origin}${path}${
     (query && `?${queryDataToUrlString(query)}`) || ""
   }`;

--- a/frontend/src/router/Link.tsx
+++ b/frontend/src/router/Link.tsx
@@ -32,10 +32,7 @@ const Link = ({
 }: LinkProps): JSX.Element => {
   const { setPage } = useContext(RouterContext);
 
-  const href =
-    to === "index"
-      ? `/`
-      : `/${to}${(query && queryDataToUrlString(query)) || ""}`;
+  const href = to === "index" ? `/` : `/${to}`;
 
   const handleClick = (e: React.MouseEvent<HTMLAnchorElement, MouseEvent>) => {
     e.preventDefault();

--- a/frontend/src/router/Link.tsx
+++ b/frontend/src/router/Link.tsx
@@ -5,13 +5,15 @@ import { LinkPath } from "router";
 import RouterContext from "./Contexts";
 
 const { history, location } = window;
+const FIRST_INDEX = 0;
+const DELETE_COUNT = 1;
 
-// TODO:state를 url에 추가하는 함수 추가하기
 const queryDataToUrlString = (query: { [key: string]: string }) => {
   return JSON.stringify(query)
     .replace(/["{}]/g, "")
     .split(",")
-    .reduce((prev, cur) => `${prev}${cur.split(":").join("=")}&`, "");
+    .reduce((prev, cur) => `${prev}${cur.split(":").join("=")}&`, "")
+    .slice(FIRST_INDEX, DELETE_COUNT * -1);
 };
 
 const pushHistory = ({ path, state, query }: PushHistoryProps): void => {

--- a/frontend/src/router/index.d.ts
+++ b/frontend/src/router/index.d.ts
@@ -1,6 +1,4 @@
-// cycle 오류로 인한 type, interface 분리
-
-// import pages from "./pages";
+// NOTE: cycle 오류로 인한 type, interface 분리
 
 export type LinkPath = "index" | "searchResult" | "notFound";
 

--- a/frontend/src/router/router.tsx
+++ b/frontend/src/router/router.tsx
@@ -19,19 +19,6 @@ const parseQueryStringToObject = (
 
 const Router = (): React.ReactElement => {
   const { location } = window;
-  // const queryData: { [key: string]: string } = useMemo(() => ({}), []);
-
-  // Object.fromEntries
-  // const queryData = location.search
-  //   .slice(1)
-  //   .split("&")
-  //   .map((item) => item.split("="))
-  //   .reduce((prev, [key, val]) => {
-  //     if (key.length) {
-  //       return { ...prev, [key]: val };
-  //     }
-  //     return { ...prev };
-  //   }, {});
 
   const getCurrentPath = (): LinkPath => {
     const currentPath =
@@ -42,18 +29,16 @@ const Router = (): React.ReactElement => {
   };
 
   const currentPath: LinkPath = getCurrentPath();
-  const { search: queryString } = location;
-  let queryData = parseQueryStringToObject(queryString);
 
-  // console.log(currentPath);
-  console.log(queryString, "queryString");
-  console.log(queryData, "queryData");
+  const { search: queryString } = location;
+
+  let queryData = parseQueryStringToObject(queryString);
 
   const [page, setPage] = useState<LinkPath>(
     pages[currentPath] ? currentPath : "notFound"
   );
 
-  onpopstate = (/* e: PopStateEvent */) => {
+  onpopstate = () => {
     const poppedPath: LinkPath = getCurrentPath();
     queryData = parseQueryStringToObject(queryString);
 
@@ -73,17 +58,7 @@ const Router = (): React.ReactElement => {
         [queryData, page, setPage]
       )}
     >
-      {/* <LocationContext.Provider
-        value={useMemo(
-          () => ({
-            queryData,
-            pathname: location.pathname,
-          }),
-          [location.pathname, queryData]
-        )}
-      > */}
       <div style={{ position: "relative" }}>{pages[page]}</div>
-      {/* </LocationContext.Provider> */}
     </RouterContext.Provider>
   );
 };

--- a/frontend/src/router/router.tsx
+++ b/frontend/src/router/router.tsx
@@ -43,7 +43,7 @@ const Router = (): React.ReactElement => {
 
   const currentPath: LinkPath = getCurrentPath();
   const { search: queryString } = location;
-  const queryData = parseQueryStringToObject(queryString);
+  let queryData = parseQueryStringToObject(queryString);
 
   // console.log(currentPath);
   console.log(queryString, "queryString");
@@ -55,6 +55,7 @@ const Router = (): React.ReactElement => {
 
   onpopstate = (/* e: PopStateEvent */) => {
     const poppedPath: LinkPath = getCurrentPath();
+    queryData = parseQueryStringToObject(queryString);
 
     if (!pages[poppedPath]) {
       setPage("notFound");

--- a/frontend/src/styles/theme.ts
+++ b/frontend/src/styles/theme.ts
@@ -107,7 +107,7 @@ const theme = createTheme({
     },
   },
   whiteSpace: {
-    inner: "80px",
+    inner: "40px",
     searchBarPadding: "64px",
   },
   components: {


### PR DESCRIPTION
## ✅ bugs

- [x] Link로 query를 props로 넘겨줄경우 이동후 주소 표시줄에 잘못된주소(중복쿼리)표시
- [x] 주소에 쿼리가 있던 검색결과화면에서, 다시 LOGO를 클릭하여 첫화면으로 돌아오면, 기존 Context로 인해 첫 화면 검색바가 잘못표시된다.
- [x] 검색결과화면에서 FullSizeSearchBar가 표시되고 있는경우 검색버튼을 누르지 않으면 minisize로 돌아오지 않는다.
- [x] 검색결과에서 `LOGO`버튼을 누르지 않고 뒤로가기로 오는경우, 검색결과 miniBar로 표시됨. 
- [x] 주소를 입력해서 검색결과화면으로 진입하면, 초기설정인 fullSize 검색바로 표시된다.
- [x] 높은 해상도에서 화면 레이아웃 문제
- [x] 검색결과화면에서 fullSize 검색바로 변경시 초기검색바처럼 나오지 않음(내부 text)
- [x] ~~`Item`~~ `SearchResult` 에서 key prop이 unique하지 않다는 오류
- [x] 첫 화면 검색바에서 세번 클릭해야 모달 표시