### PR TITLE
[FE] 검색 필터 표시 및 지도 버튼 동작

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -108,6 +108,7 @@
     "eslint-config-airbnb-typescript": "^17.0.0",
     "eslint-config-prettier": "^8.5.0",
     "eslint-import-resolver-typescript": "^2.7.1",
-    "eslint-plugin-import": "^2.26.0"
+    "eslint-plugin-import": "^2.26.0",
+    "kakao.maps.d.ts": "^0.1.32"
   }
 }

--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -17,7 +17,7 @@
     <div id="root"></div>
     <script
       type="text/javascript"
-      src="//dapi.kakao.com/v2/maps/sdk.js?appkey=%REACT_APP_MAP_KEY%"
+      src="//dapi.kakao.com/v2/maps/sdk.js?appkey=%REACT_APP_MAP_KEY%&libraries=services,drawing"
     ></script>
     <!--
       This HTML file is a template.

--- a/frontend/src/components/Header/SearchBar/ModalInnerItems/ReservationFeeModal/PriceSelectArea.tsx
+++ b/frontend/src/components/Header/SearchBar/ModalInnerItems/ReservationFeeModal/PriceSelectArea.tsx
@@ -3,7 +3,7 @@ import { useContext } from "react";
 import { Box } from "@mui/material";
 
 import { PriceRangeContext } from "contexts/contexts";
-import numToWon from "utils/utils";
+import { numToWon } from "utils/utils";
 
 import PriceChart from "./PriceChart";
 import RangeSlider from "./RangeSlider";

--- a/frontend/src/components/Header/SearchBar/SearchBar.style.ts
+++ b/frontend/src/components/Header/SearchBar/SearchBar.style.ts
@@ -14,10 +14,8 @@ const SearchBarContainer = styled(Container, {
       padding: ${elementSize.searchBar.fullSize.padding};
       `
       : `
-        width: auto;
-        min-width: ${elementSize.searchBar.miniSize.width};
-        max-width: 410px;
-        max-height: ${elementSize.searchBar.miniSize.height};
+        width: ${elementSize.searchBar.miniSize.width};
+        min-height: ${elementSize.searchBar.miniSize.height};
         padding: ${elementSize.searchBar.miniSize.padding};
       `;
 

--- a/frontend/src/components/Header/SearchBar/SearchBar.style.ts
+++ b/frontend/src/components/Header/SearchBar/SearchBar.style.ts
@@ -14,8 +14,10 @@ const SearchBarContainer = styled(Container, {
       padding: ${elementSize.searchBar.fullSize.padding};
       `
       : `
-        width: ${elementSize.searchBar.miniSize.width};
-        height: ${elementSize.searchBar.miniSize.height};
+        width: auto;
+        min-width: ${elementSize.searchBar.miniSize.width};
+        max-width: 410px;
+        max-height: ${elementSize.searchBar.miniSize.height};
         padding: ${elementSize.searchBar.miniSize.padding};
       `;
 

--- a/frontend/src/components/Header/SearchBar/SelectItemArea/SelectItem/CheckInOut.tsx
+++ b/frontend/src/components/Header/SearchBar/SelectItemArea/SelectItem/CheckInOut.tsx
@@ -4,6 +4,7 @@ import { Grid } from "@mui/material";
 
 import { SearchBarStateContext } from "contexts/contexts";
 import RouterContext from "router/Contexts";
+import { getFormattedDate } from "utils/utils";
 
 import ButtonArea from "../ButtonArea/ButtonArea";
 import { ModalTemplate } from "../SelectItemTemplate/SelectItemTemplate";
@@ -19,7 +20,7 @@ const CheckInOut = ({
   const { isSearchBarFullSize, setIsSearchBarFullSize } = useContext(
     SearchBarStateContext
   )!;
-  const { page } = { ...useContext(RouterContext) };
+  const { queryData, page } = { ...useContext(RouterContext) };
 
   const $wrap = useRef<HTMLDivElement>(null);
   const isOpen = anchorEl?.id === wrapperId;
@@ -27,6 +28,21 @@ const CheckInOut = ({
   const handleClick = () => {
     setAnchorEl?.($wrap.current);
   };
+
+  const isQueryDataIncludesDateRange =
+    !!queryData?.checkIn || !!queryData?.checkOut;
+
+  const checkInDesc =
+    (!!queryData?.checkIn && `${getFormattedDate(queryData.checkIn)}`) || "";
+
+  const checkOutDesc =
+    (!!queryData?.checkOut && `${getFormattedDate(queryData.checkOut)}`) || "";
+
+  const description =
+    isQueryDataIncludesDateRange && page !== "index"
+      ? `${checkInDesc} - 
+      ${checkOutDesc}`
+      : "일정입력";
 
   return (
     <Grid
@@ -46,7 +62,7 @@ const CheckInOut = ({
             buttonId="check-in-date-button"
             buttonAreaLabel="체크인 날짜 설정"
             title="체크인"
-            desc="날짜입력"
+            desc={checkInDesc || "날짜입력"}
             handleClick={handleClick}
             open={isOpen}
           />
@@ -58,7 +74,7 @@ const CheckInOut = ({
             buttonId="check-out-date-button"
             buttonAreaLabel="체크아웃 날짜 설정"
             title="체크아웃"
-            desc="체크아웃 영역"
+            desc={checkOutDesc || "날짜 입력"}
             handleClick={handleClick}
             open={isOpen}
           />
@@ -74,7 +90,8 @@ const CheckInOut = ({
           buttonId="check-in-out-date-button"
           buttonAreaLabel="체크인, 체크아웃 날짜 설정"
           title="체크인"
-          desc="일정입력"
+          desc={description}
+          isDiscriptionFiltered={isQueryDataIncludesDateRange}
           open={isOpen}
           anchorEl={anchorEl}
           handleClick={() => {

--- a/frontend/src/components/Header/SearchBar/SelectItemArea/SelectItem/PeopleCount.tsx
+++ b/frontend/src/components/Header/SearchBar/SelectItemArea/SelectItem/PeopleCount.tsx
@@ -20,11 +20,12 @@ const PeopleCount = ({
 
   const isPeopleCountFiltered = !!queryData?.numAdult || !!queryData?.numChild;
 
-  const description = isPeopleCountFiltered
-    ? `게스트 ${
-        (Number(queryData.numAdult) || 0) + (Number(queryData.numChild) || 0)
-      }명`
-    : "금액 설정";
+  const description =
+    isPeopleCountFiltered && page !== "index"
+      ? `게스트 ${
+          (Number(queryData.numAdult) || 0) + (Number(queryData.numChild) || 0)
+        }명`
+      : "게스트 추가";
 
   const isOpen = anchorEl?.id === buttonId;
 
@@ -45,9 +46,7 @@ const PeopleCount = ({
         buttonId={buttonId}
         buttonAreaLabel="숙박 인원 설정"
         title="인원"
-        desc={
-          isSearchBarFullSize || page === "index" ? "게스트 추가" : description
-        }
+        desc={description}
         isDiscriptionFiltered={isPeopleCountFiltered}
         open={isOpen}
         handleClick={

--- a/frontend/src/components/Header/SearchBar/SelectItemArea/SelectItem/PeopleCount.tsx
+++ b/frontend/src/components/Header/SearchBar/SelectItemArea/SelectItem/PeopleCount.tsx
@@ -16,7 +16,15 @@ const PeopleCount = ({
   const { isSearchBarFullSize, setIsSearchBarFullSize } = useContext(
     SearchBarStateContext
   )!;
-  const { page } = { ...useContext(RouterContext) };
+  const { queryData, page } = { ...useContext(RouterContext) };
+
+  const isPeopleCountFiltered = !!queryData?.numAdult || !!queryData?.numChild;
+
+  const description = isPeopleCountFiltered
+    ? `게스트 ${
+        (Number(queryData.numAdult) || 0) + (Number(queryData.numChild) || 0)
+      }명`
+    : "금액 설정";
 
   const isOpen = anchorEl?.id === buttonId;
 
@@ -38,8 +46,9 @@ const PeopleCount = ({
         buttonAreaLabel="숙박 인원 설정"
         title="인원"
         desc={
-          isSearchBarFullSize || page === "index" ? "게스트 추가" : "인원 입력"
+          isSearchBarFullSize || page === "index" ? "게스트 추가" : description
         }
+        isDiscriptionFiltered={isPeopleCountFiltered}
         open={isOpen}
         handleClick={
           isSearchBarFullSize || page === "index"

--- a/frontend/src/components/Header/SearchBar/SelectItemArea/SelectItem/PeopleCount.tsx
+++ b/frontend/src/components/Header/SearchBar/SelectItemArea/SelectItem/PeopleCount.tsx
@@ -18,10 +18,11 @@ const PeopleCount = ({
   )!;
   const { queryData, page } = { ...useContext(RouterContext) };
 
-  const isPeopleCountFiltered = !!queryData?.numAdult || !!queryData?.numChild;
+  const isQueryDataIncludesPepoleCount =
+    !!queryData?.numAdult || !!queryData?.numChild;
 
   const description =
-    isPeopleCountFiltered && page !== "index"
+    isQueryDataIncludesPepoleCount && page !== "index"
       ? `게스트 ${
           (Number(queryData.numAdult) || 0) + (Number(queryData.numChild) || 0)
         }명`
@@ -47,7 +48,7 @@ const PeopleCount = ({
         buttonAreaLabel="숙박 인원 설정"
         title="인원"
         desc={description}
-        isDiscriptionFiltered={isPeopleCountFiltered}
+        isDiscriptionFiltered={isQueryDataIncludesPepoleCount}
         open={isOpen}
         handleClick={
           isSearchBarFullSize || page === "index"

--- a/frontend/src/components/Header/SearchBar/SelectItemArea/SelectItem/ReservationFee.tsx
+++ b/frontend/src/components/Header/SearchBar/SelectItemArea/SelectItem/ReservationFee.tsx
@@ -51,11 +51,12 @@ const ReservationFee = ({
   const isDiscriptionFiltered =
     !!isQueryDataIncludesPriceRange || !!isReservationFeeFiltered;
 
-  const description = isDiscriptionFiltered
-    ? `${numToWon(Number(queryData?.minPrice) || price.min)} - ${numToWon(
-        Number(queryData?.maxPrice) || price.max
-      )}`
-    : "금액 설정";
+  const description =
+    isDiscriptionFiltered && page !== "index"
+      ? `${numToWon(Number(queryData?.minPrice) || price.min)} - ${numToWon(
+          Number(queryData?.maxPrice) || price.max
+        )}`
+      : "금액 설정";
 
   const isOpen = anchorEl?.id === buttonId;
 

--- a/frontend/src/components/Header/SearchBar/SelectItemArea/SelectItem/ReservationFee.tsx
+++ b/frontend/src/components/Header/SearchBar/SelectItemArea/SelectItem/ReservationFee.tsx
@@ -42,20 +42,20 @@ const ReservationFee = ({
   };
 
   const isQueryDataIncludesPriceRange =
-    queryData?.minPrice || queryData?.maxPrice || false;
+    !!queryData?.minPrice || !!queryData?.maxPrice;
 
   const isReservationFeeFiltered =
     percentage.min !== INITIAL_PRICE_PERCENTAGE.min ||
     percentage.max !== INITIAL_PRICE_PERCENTAGE.max;
 
-  // price랑.. percentage랑 어떻게 잘 버무려서 query받아온 숫자로 보여주면 될듯.. 55줄을
+  const isDiscriptionFiltered =
+    !!isQueryDataIncludesPriceRange || !!isReservationFeeFiltered;
 
-  const description =
-    isQueryDataIncludesPriceRange || isReservationFeeFiltered
-      ? `${numToWon(Number(queryData?.minPrice) || price.min)} - ${numToWon(
-          Number(queryData?.maxPrice) || price.max
-        )}`
-      : "금액 설정";
+  const description = isDiscriptionFiltered
+    ? `${numToWon(Number(queryData?.minPrice) || price.min)} - ${numToWon(
+        Number(queryData?.maxPrice) || price.max
+      )}`
+    : "금액 설정";
 
   const isOpen = anchorEl?.id === buttonId;
 
@@ -85,6 +85,7 @@ const ReservationFee = ({
               }
             : { xs: 3, pl: 1 }
         }
+        isDiscriptionFiltered={isDiscriptionFiltered}
         buttonId={buttonId}
         buttonAreaLabel="숙박요금 설정"
         title="요금"

--- a/frontend/src/components/Header/SearchBar/SelectItemArea/SelectItem/ReservationFee.tsx
+++ b/frontend/src/components/Header/SearchBar/SelectItemArea/SelectItem/ReservationFee.tsx
@@ -53,7 +53,7 @@ const ReservationFee = ({
 
   const description =
     isDiscriptionFiltered && page !== "index"
-      ? `${numToWon(Number(queryData?.minPrice) || price.min)} - ${numToWon(
+      ? `₩${numToWon(Number(queryData?.minPrice) || price.min)} - ₩${numToWon(
           Number(queryData?.maxPrice) || price.max
         )}`
       : "금액 설정";

--- a/frontend/src/components/Header/SearchBar/SelectItemArea/SelectItem/ReservationFee.tsx
+++ b/frontend/src/components/Header/SearchBar/SelectItemArea/SelectItem/ReservationFee.tsx
@@ -52,10 +52,13 @@ const ReservationFee = ({
 
   const description =
     isQueryDataIncludesPriceRange || isReservationFeeFiltered
-      ? `${numToWon(price.min)} - ${numToWon(price.max)}`
+      ? `${numToWon(Number(queryData?.minPrice) || price.min)} - ${numToWon(
+          Number(queryData?.maxPrice) || price.max
+        )}`
       : "금액 설정";
 
   const isOpen = anchorEl?.id === buttonId;
+
   return (
     <PriceRangeContext.Provider
       value={useMemo(

--- a/frontend/src/components/Header/SearchBar/SelectItemArea/SelectItem/ReservationFee.tsx
+++ b/frontend/src/components/Header/SearchBar/SelectItemArea/SelectItem/ReservationFee.tsx
@@ -2,7 +2,7 @@ import { useState, useContext, useMemo } from "react";
 
 import { PriceRangeContext, SearchBarStateContext } from "contexts/contexts";
 import RouterContext from "router/Contexts";
-import numToWon from "utils/utils";
+import { numToWon } from "utils/utils";
 
 import PriceSelectArea from "../../ModalInnerItems/ReservationFeeModal/PriceSelectArea";
 import ButtonArea from "../ButtonArea/ButtonArea";
@@ -40,15 +40,20 @@ const ReservationFee = ({
     state: RangeType;
     setState: React.Dispatch<React.SetStateAction<RangeType>>;
   };
+
   const isQueryDataIncludesPriceRange =
-    queryData?.minPrice || queryData?.maxPrice;
+    queryData?.minPrice || queryData?.maxPrice || false;
+
+  const isReservationFeeFiltered =
+    percentage.min !== INITIAL_PRICE_PERCENTAGE.min ||
+    percentage.max !== INITIAL_PRICE_PERCENTAGE.max;
+
+  // price랑.. percentage랑 어떻게 잘 버무려서 query받아온 숫자로 보여주면 될듯.. 55줄을
 
   const description =
-    !isQueryDataIncludesPriceRange &&
-    percentage.min === INITIAL_PRICE_PERCENTAGE.min &&
-    percentage.max === INITIAL_PRICE_PERCENTAGE.max
-      ? "금액 설정"
-      : `${numToWon(price.min)}~${numToWon(price.max)}`;
+    isQueryDataIncludesPriceRange || isReservationFeeFiltered
+      ? `${numToWon(price.min)} - ${numToWon(price.max)}`
+      : "금액 설정";
 
   const isOpen = anchorEl?.id === buttonId;
   return (

--- a/frontend/src/components/Header/SearchBar/SelectItemArea/SelectItem/SelectItem.style.ts
+++ b/frontend/src/components/Header/SearchBar/SelectItemArea/SelectItem/SelectItem.style.ts
@@ -26,6 +26,7 @@ const SelectItemStyle = {
     color: ({ palette }: Theme) => palette.grey3.main,
     fontSize: ({ style }: Theme) => style.miniSearchButton.fontSize,
     fontWeight: ({ style }: Theme) => style.miniSearchButton.fontWeight,
+    whiteSpace: "pre-line",
     ...getEllipisisStyle(2),
   },
   border: {

--- a/frontend/src/components/Header/SearchBar/SelectItemArea/SelectItem/SelectItem.style.ts
+++ b/frontend/src/components/Header/SearchBar/SelectItemArea/SelectItem/SelectItem.style.ts
@@ -1,5 +1,7 @@
 import { Theme } from "@mui/material";
 
+import { getEllipisisStyle } from "utils/utils";
+
 const SelectItemStyle = {
   button: {
     flexDirection: "column",
@@ -24,6 +26,7 @@ const SelectItemStyle = {
     color: ({ palette }: Theme) => palette.grey3.main,
     fontSize: ({ style }: Theme) => style.miniSearchButton.fontSize,
     fontWeight: ({ style }: Theme) => style.miniSearchButton.fontWeight,
+    ...getEllipisisStyle(2),
   },
   border: {
     borderRight: ({ palette }: { palette: { grey5: { main: string } } }) =>

--- a/frontend/src/components/Header/SearchBar/SelectItemArea/SelectItem/SelectItem.tsx
+++ b/frontend/src/components/Header/SearchBar/SelectItemArea/SelectItem/SelectItem.tsx
@@ -10,6 +10,7 @@ import {
 
 import { SearchBarStateContext } from "contexts/contexts";
 import RouterContext from "router/Contexts";
+import theme from "styles/theme";
 
 import {
   ModalTemplate,
@@ -32,6 +33,7 @@ const SelectItem = ({ ...props }: SelectItemDataProps): JSX.Element => {
     anchorEl,
     children,
     createNewPopup,
+    isDiscriptionFiltered,
   } = props;
 
   const { isSearchBarFullSize } = { ...useContext(SearchBarStateContext) };
@@ -51,13 +53,13 @@ const SelectItem = ({ ...props }: SelectItemDataProps): JSX.Element => {
         {(isSearchBarFullSize || page === "index") && (
           <Typography sx={itemStyles.title}>{title}</Typography>
         )}
-        {/* 쿼리데이터가 없는 경우 표시 */}
         <Typography
-          sx={
-            isSearchBarFullSize || page === "index"
+          sx={{
+            ...(isSearchBarFullSize || page === "index"
               ? itemStyles.desc
-              : itemStyles.miniSizeDesc
-          }
+              : itemStyles.miniSizeDesc),
+            ...(isDiscriptionFiltered && { color: theme.palette.black.main }),
+          }}
         >
           {desc}
         </Typography>
@@ -103,6 +105,7 @@ export interface SelectItemDataProps extends PopoverProps {
   handleClick?: (event: React.MouseEvent<HTMLElement>) => void;
   handleClose?: () => void;
   createNewPopup?: boolean;
+  isDiscriptionFiltered?: boolean;
 }
 
 export interface SelectItemProps {

--- a/frontend/src/components/Header/SearchBar/SelectItemArea/SelectItemArea.tsx
+++ b/frontend/src/components/Header/SearchBar/SelectItemArea/SelectItemArea.tsx
@@ -79,7 +79,14 @@ const SelectItemArea = (): JSX.Element => {
               : handleMiniSearchBarClick
           }
           query={{
-            test: "test1", // 쿼리 테스트용
+            // 테스트용 데이터
+            checkIn: "2022-01-01",
+            checkOut: "2022-03-01",
+            maxPrice: "500000",
+            minPrice: "80000",
+            numAdult: "2",
+            numChild: "0",
+            numInfant: "1",
           }}
         >
           <ButtonArea

--- a/frontend/src/components/Main/SearchResult/AccomodationsList/Filter/Filter.tsx
+++ b/frontend/src/components/Main/SearchResult/AccomodationsList/Filter/Filter.tsx
@@ -1,7 +1,7 @@
 import { useContext } from "react";
 
 import RouterContext from "router/Contexts";
-import numToWon from "utils/utils";
+import { numToWon } from "utils/utils";
 
 import Item from "./Item";
 
@@ -46,7 +46,6 @@ const getDataListFromQueryData = (data: { [key: string]: string }) => {
 };
 
 const Filter = () => {
-
   const { queryData } = { ...useContext(RouterContext) };
 
   return (

--- a/frontend/src/components/Main/SearchResult/AccomodationsList/Filter/Filter.tsx
+++ b/frontend/src/components/Main/SearchResult/AccomodationsList/Filter/Filter.tsx
@@ -33,11 +33,6 @@ const getDataListFromQueryData = (data: { [key: string]: string }) => {
   }
 
   if (data.minPrice || data.maxPrice) {
-    console.log(
-      Number(data?.maxPrice),
-      data?.maxPrice,
-      numToWon(Number(data?.maxPrice))
-    );
     result.push([
       "priceRange",
       `₩${

--- a/frontend/src/components/Main/SearchResult/AccomodationsList/Filter/Filter.tsx
+++ b/frontend/src/components/Main/SearchResult/AccomodationsList/Filter/Filter.tsx
@@ -1,13 +1,21 @@
 import { useContext } from "react";
 
 import RouterContext from "router/Contexts";
-import { numToWon } from "utils/utils";
+import { getFormattedDate, numToWon } from "utils/utils";
 
 import Item from "./Item";
 
+// TODO: API사용시 API로부터 받아온 min, maxPrice로 변경
+const initialPrice = {
+  minPrice: 10000,
+  maxPrice: 10000000,
+};
+
 // NOTE: count: 0, // 숙소 개수. <-- 결과에서 가져와야함. length로?
+
 const getDataListFromQueryData = (data: { [key: string]: string }) => {
   const result = [];
+
   if (data.NumAdult || data.numChild) {
     const guestCount = `게스트 ${
       Number(data.numAdult) + Number(data.numChild)
@@ -16,32 +24,27 @@ const getDataListFromQueryData = (data: { [key: string]: string }) => {
     result.push(["guestCount", guestCount]);
   }
 
-  if (data.checkIn) {
-    let checkInOut = `${data.checkIn}~`;
-    if (data.checkOut) {
-      checkInOut += ` ${data.checkOut}`;
-    }
-    result.push(["checkInOut", checkInOut]);
+  if (data.checkIn || data.checkOut) {
+    const checkInStr =
+      (!!data?.checkIn && `${getFormattedDate(data.checkIn)}`) || "";
+    const checkOutStr =
+      (!!data?.checkOut && `${getFormattedDate(data.checkOut)}`) || "";
+    result.push(["checkInOut", `${checkInStr} ~ ${checkOutStr}`]);
   }
 
-  if (!data.checkIn && data.checkOut) {
-    const checkInOut = `${data.checkOut} 까지`;
-    result.push(["checkInOut", checkInOut]);
+  if (data.minPrice || data.maxPrice) {
+    console.log(
+      Number(data?.maxPrice),
+      data?.maxPrice,
+      numToWon(Number(data?.maxPrice))
+    );
+    result.push([
+      "priceRange",
+      `₩${
+        numToWon(Number(data?.minPrice)) || initialPrice.minPrice
+      } - ₩${numToWon(Number(data?.maxPrice) || initialPrice.maxPrice)}`,
+    ]);
   }
-
-  if (data.minPrice) {
-    let priceRange = `${numToWon(Number(data.minPrice))} ~`;
-    if (data.maxPrice) {
-      priceRange += ` ${numToWon(Number(data.maxPrice))}`;
-    }
-    result.push(["priceRange", priceRange]);
-  }
-
-  if (!data.minPrice && data.maxPrice) {
-    const priceRange = `${numToWon(Number(data.maxPrice))} 까지`;
-    result.push(["priceRange", priceRange]);
-  }
-
   return result;
 };
 

--- a/frontend/src/components/Main/SearchResult/AccomodationsList/ListItemCard/ListItemCard.tsx
+++ b/frontend/src/components/Main/SearchResult/AccomodationsList/ListItemCard/ListItemCard.tsx
@@ -1,4 +1,4 @@
-import numToWon from "utils/utils";
+import { numToWon } from "utils/utils";
 
 const ListItemCard = ({
   name,

--- a/frontend/src/components/Main/SearchResult/MapArea/MapArea.style.ts
+++ b/frontend/src/components/Main/SearchResult/MapArea/MapArea.style.ts
@@ -1,0 +1,41 @@
+import styled from "@emotion/styled";
+
+import theme from "styles/theme";
+
+const Wrapper = styled.div`
+  flex: 55;
+  z-index: -1;
+  position: relative;
+
+  .map-area {
+    width: 100%;
+    height: 100%;
+    z-index: -1;
+  }
+
+  .float-item {
+    position: absolute;
+  }
+
+  .map-checkbox-wrap {
+    background-color: ${theme.palette.white.main};
+    top: 30px;
+    right: calc(50% - ${210 / 2}px);
+    width: 210px;
+    font-size: 14px;
+    padding-right: 10px;
+    border-radius: 0.5rem;
+    box-shadow: 0px 0px 15px 5px rgba(0, 0, 0, 0.1);
+
+    .MuiFormControlLabel-root {
+      margin: 0;
+    }
+
+    .MuiSvgIcon-root {
+      width: 32px;
+      height: 32px;
+    }
+  }
+`;
+
+export default Wrapper;

--- a/frontend/src/components/Main/SearchResult/MapArea/MapArea.style.ts
+++ b/frontend/src/components/Main/SearchResult/MapArea/MapArea.style.ts
@@ -36,6 +36,29 @@ const Wrapper = styled.div`
       height: 32px;
     }
   }
+
+  .zoom-button {
+    display: flex;
+    top: 30px;
+    right: 30px;
+    padding: 3px;
+    flex-direction: column;
+    background-color: #fff;
+    border-radius: 0.5rem;
+    box-shadow: 0px 0px 15px 5px rgba(0, 0, 0, 0.1);
+
+    .MuiButtonBase-root {
+      border-radius: 0;
+    }
+
+    .MuiButtonBase-root:not(:last-child) {
+      border-bottom: 1px solid #e0e0e0;
+    }
+
+    .MuiSvgIcon-root {
+      width: 24px;
+    }
+  }
 `;
 
 export default Wrapper;

--- a/frontend/src/components/Main/SearchResult/MapArea/MapArea.tsx
+++ b/frontend/src/components/Main/SearchResult/MapArea/MapArea.tsx
@@ -1,6 +1,8 @@
 import { useEffect, useRef } from "react";
 
-import { Checkbox, FormControlLabel } from "@mui/material";
+import AddIcon from "@mui/icons-material/Add";
+import RemoveIcon from "@mui/icons-material/Remove";
+import { Checkbox, FormControlLabel, IconButton } from "@mui/material";
 
 import Wrapper from "./MapArea.style";
 
@@ -33,7 +35,14 @@ const MapArea = () => {
           label="지도를 움직이며 검색하기"
         />
       </div>
-      <div className="zoom-button float-item">줌인줌아웃</div>
+      <div className="zoom-button float-item">
+        <IconButton aria-label="지도 확대하기" component="span">
+          <AddIcon />
+        </IconButton>
+        <IconButton aria-label="지도 축소하기" component="span">
+          <RemoveIcon />
+        </IconButton>
+      </div>
     </Wrapper>
   );
 };

--- a/frontend/src/components/Main/SearchResult/MapArea/MapArea.tsx
+++ b/frontend/src/components/Main/SearchResult/MapArea/MapArea.tsx
@@ -1,5 +1,9 @@
 import { useEffect, useRef } from "react";
 
+import { Checkbox, FormControlLabel } from "@mui/material";
+
+import Wrapper from "./MapArea.style";
+
 const { kakao } = window;
 
 const mapOption = {
@@ -18,7 +22,20 @@ const MapArea = () => {
     map.current = new kakao.maps.Map(mapContainer, mapOption);
   }, []);
 
-  return <div className="map-area" ref={$mapArea} />;
+  return (
+    <Wrapper>
+      <div className="map-area" ref={$mapArea} />
+      <div className="map-checkbox-wrap float-item">
+        <FormControlLabel
+          control={
+            <Checkbox defaultChecked color="grey2" aria-label="Checkbox" />
+          }
+          label="지도를 움직이며 검색하기"
+        />
+      </div>
+      <div className="zoom-button float-item">줌인줌아웃</div>
+    </Wrapper>
+  );
 };
 
 export default MapArea;

--- a/frontend/src/components/Main/SearchResult/MapArea/MapArea.tsx
+++ b/frontend/src/components/Main/SearchResult/MapArea/MapArea.tsx
@@ -8,9 +8,11 @@ import Wrapper from "./MapArea.style";
 
 const { kakao } = window;
 
+const INITIAL_MAP_LEVEL = 3;
+
 const mapOption = {
   center: new kakao.maps.LatLng(33.450701, 126.570667),
-  level: 3,
+  level: INITIAL_MAP_LEVEL,
 };
 
 const MapArea = () => {

--- a/frontend/src/components/Main/SearchResult/MapArea/MapArea.tsx
+++ b/frontend/src/components/Main/SearchResult/MapArea/MapArea.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from "react";
+import { useEffect, useRef, useState } from "react";
 
 import AddIcon from "@mui/icons-material/Add";
 import RemoveIcon from "@mui/icons-material/Remove";
@@ -15,14 +15,23 @@ const mapOption = {
 
 const MapArea = () => {
   const $mapArea = useRef<HTMLDivElement | null>(null);
-  const map = useRef(null);
+  const map = useRef<kakao.maps.Map | null>(null);
+
+  const [isMapDraggable, setIsMapDraggable] = useState(true);
+
+  const handleMapCheckboxClick = () => {
+    setIsMapDraggable(!isMapDraggable);
+  };
 
   useEffect(() => {
     const mapContainer = $mapArea.current;
 
-    // TODO: new Lint오류로 임시로 ref이용, 추후 개선
     map.current = new kakao.maps.Map(mapContainer, mapOption);
   }, []);
+
+  useEffect(() => {
+    map.current?.setDraggable(isMapDraggable);
+  }, [isMapDraggable]);
 
   return (
     <Wrapper>
@@ -30,7 +39,12 @@ const MapArea = () => {
       <div className="map-checkbox-wrap float-item">
         <FormControlLabel
           control={
-            <Checkbox defaultChecked color="grey2" aria-label="Checkbox" />
+            <Checkbox
+              defaultChecked
+              color="grey2"
+              aria-label="Checkbox"
+              onClick={handleMapCheckboxClick}
+            />
           }
           label="지도를 움직이며 검색하기"
         />

--- a/frontend/src/components/Main/SearchResult/MapArea/MapArea.tsx
+++ b/frontend/src/components/Main/SearchResult/MapArea/MapArea.tsx
@@ -50,10 +50,18 @@ const MapArea = () => {
         />
       </div>
       <div className="zoom-button float-item">
-        <IconButton aria-label="지도 확대하기" component="span">
+        <IconButton
+          aria-label="지도 확대하기"
+          component="span"
+          onClick={() => map.current?.setLevel(map.current.getLevel() - 1)}
+        >
           <AddIcon />
         </IconButton>
-        <IconButton aria-label="지도 축소하기" component="span">
+        <IconButton
+          aria-label="지도 축소하기"
+          component="span"
+          onClick={() => map.current?.setLevel(map.current.getLevel() + 1)}
+        >
           <RemoveIcon />
         </IconButton>
       </div>

--- a/frontend/src/components/Main/SearchResult/SearchResult.style.ts
+++ b/frontend/src/components/Main/SearchResult/SearchResult.style.ts
@@ -2,7 +2,7 @@ import { Container, ContainerProps } from "@mui/material";
 import { styled } from "@mui/material/styles";
 
 const Wrapper = styled(Container)<ContainerProps>(
-  ({ theme: { elementSize, whiteSpace, palette } }) => `
+  ({ theme: { elementSize, whiteSpace } }) => `
   display: flex;
   position: absolute;
   z-index: -1;
@@ -14,12 +14,6 @@ const Wrapper = styled(Container)<ContainerProps>(
     100vh - ${parseInt(elementSize.header.others.height, 10)}px
   );
   padding:  0 ${whiteSpace.inner} !important;
-
-  .map-area {
-    background-color: #999;
-    flex: 55;
-    z-index: -1;
-  }
 
   .accomodations-list-area {
     flex: 45;
@@ -102,28 +96,6 @@ const Wrapper = styled(Container)<ContainerProps>(
       text-decoration: underline;
     }
 
-  }
-
-  .float-item {
-    position: absolute;
-    top: 0;
-    right: 3rem;
-  }
-
-  .map-checkbox-wrap {
-    background-color: ${palette.white.main};
-    font-size: 14px;
-    padding: 10px 12px;
-    border-radius: 0.5rem;
-
-    .MuiFormControlLabel-root {
-      margin: 0;
-    }
-
-    .MuiSvgIcon-root {
-      width: 32px;
-      height: 32px;
-    }
   }
 `
 );

--- a/frontend/src/components/Main/SearchResult/SearchResult.style.ts
+++ b/frontend/src/components/Main/SearchResult/SearchResult.style.ts
@@ -2,7 +2,7 @@ import { Container, ContainerProps } from "@mui/material";
 import { styled } from "@mui/material/styles";
 
 const Wrapper = styled(Container)<ContainerProps>(
-  ({ theme: { elementSize, whiteSpace } }) => `
+  ({ theme: { elementSize, whiteSpace, palette } }) => `
   display: flex;
   position: absolute;
   z-index: -1;
@@ -108,6 +108,22 @@ const Wrapper = styled(Container)<ContainerProps>(
     position: absolute;
     top: 0;
     right: 3rem;
+  }
+
+  .map-checkbox-wrap {
+    background-color: ${palette.white.main};
+    font-size: 14px;
+    padding: 10px 12px;
+    border-radius: 0.5rem;
+
+    .MuiFormControlLabel-root {
+      margin: 0;
+    }
+
+    .MuiSvgIcon-root {
+      width: 32px;
+      height: 32px;
+    }
   }
 `
 );

--- a/frontend/src/components/Main/SearchResult/SearchResult.style.ts
+++ b/frontend/src/components/Main/SearchResult/SearchResult.style.ts
@@ -18,6 +18,7 @@ const Wrapper = styled(Container)<ContainerProps>(
   .map-area {
     background-color: #999;
     flex: 55;
+    z-index: -1;
   }
 
   .accomodations-list-area {
@@ -100,6 +101,13 @@ const Wrapper = styled(Container)<ContainerProps>(
       color: #828282;
       text-decoration: underline;
     }
+
+  }
+
+  .float-item {
+    position: absolute;
+    top: 0;
+    right: 3rem;
   }
 `
 );

--- a/frontend/src/components/Main/SearchResult/SearchResult.tsx
+++ b/frontend/src/components/Main/SearchResult/SearchResult.tsx
@@ -10,16 +10,34 @@ import ListItemCard from "./AccomodationsList/ListItemCard/ListItemCard";
 import MapArea from "./MapArea/MapArea";
 import Wrapper from "./SearchResult.style";
 
+const requiredQueryKeys = [
+  "checkIn",
+  "checkOut",
+  "maxPrice",
+  "minPrice",
+  "numAdult",
+  "numChild",
+  "numInfant",
+];
+
 const SearchResult = (): JSX.Element => {
   const { queryData } = { ...useContext(RouterContext) };
+
+  const isQueryDataIncludesKey = (keyName: string) => {
+    return queryData?.[keyName];
+  };
+
+  const isQueryDataIncludesRequiredQueryKeys = requiredQueryKeys.some(
+    isQueryDataIncludesKey
+  );
 
   return (
     <Box component="main">
       <Wrapper maxWidth="xl">
-        {(queryData && (
+        {(isQueryDataIncludesRequiredQueryKeys && (
           <>
             <div className="accomodations-list-area">
-              {queryData && <Filter />}
+              <Filter />
               <h2 className="title">지도에서 선택한 지역의 숙소</h2>
               <ul className="accomodations-list">
                 {

--- a/frontend/src/components/Main/SearchResult/SearchResult.tsx
+++ b/frontend/src/components/Main/SearchResult/SearchResult.tsx
@@ -1,6 +1,6 @@
 import { useContext } from "react";
 
-import { Box } from "@mui/material";
+import { Box, Checkbox, FormControlLabel } from "@mui/material";
 
 import NotFound from "components/NotFound/NotFound";
 import RouterContext from "router/Contexts";
@@ -92,8 +92,17 @@ const SearchResult = (): JSX.Element => {
               </ul>
             </div>
             <MapArea />
-            <div className="map-check-box float-item">
-              지도를 움직이며 검색하기
+            <div className="map-checkbox-wrap float-item">
+              <FormControlLabel
+                control={
+                  <Checkbox
+                    defaultChecked
+                    color="grey2"
+                    aria-label="Checkbox"
+                  />
+                }
+                label="지도를 움직이며 검색하기"
+              />
             </div>
             <div className="zoom-button float-item">줌인줌아웃</div>
           </>

--- a/frontend/src/components/Main/SearchResult/SearchResult.tsx
+++ b/frontend/src/components/Main/SearchResult/SearchResult.tsx
@@ -1,6 +1,6 @@
 import { useContext } from "react";
 
-import { Box, Checkbox, FormControlLabel } from "@mui/material";
+import { Box } from "@mui/material";
 
 import NotFound from "components/NotFound/NotFound";
 import RouterContext from "router/Contexts";
@@ -92,19 +92,6 @@ const SearchResult = (): JSX.Element => {
               </ul>
             </div>
             <MapArea />
-            <div className="map-checkbox-wrap float-item">
-              <FormControlLabel
-                control={
-                  <Checkbox
-                    defaultChecked
-                    color="grey2"
-                    aria-label="Checkbox"
-                  />
-                }
-                label="지도를 움직이며 검색하기"
-              />
-            </div>
-            <div className="zoom-button float-item">줌인줌아웃</div>
           </>
         )) || <NotFound />}
       </Wrapper>

--- a/frontend/src/components/Main/SearchResult/SearchResult.tsx
+++ b/frontend/src/components/Main/SearchResult/SearchResult.tsx
@@ -92,6 +92,10 @@ const SearchResult = (): JSX.Element => {
               </ul>
             </div>
             <MapArea />
+            <div className="map-check-box float-item">
+              지도를 움직이며 검색하기
+            </div>
+            <div className="zoom-button float-item">줌인줌아웃</div>
           </>
         )) || <NotFound />}
       </Wrapper>

--- a/frontend/src/router/router.tsx
+++ b/frontend/src/router/router.tsx
@@ -8,13 +8,27 @@ import pages from "./pages";
 const FIRST_INDEX = 0;
 const FIRST_CHAR_COUNT = 1;
 
+// const queryKeysForSearchBarFilter = [
+//   "checkIn",
+//   "checkOut",
+//   "maxPrice",
+//   "minPrice",
+//   "numAdult",
+//   "numChild",
+// ];
+
 const parseQueryStringToObject = (
   queryString: string
 ): { [key: string]: string } | null => {
   if (!queryString.length) {
     return null;
   }
-  return Object.fromEntries(queryString.split("&").map((s) => s.split("=")));
+  return Object.fromEntries(
+    queryString
+      .slice(FIRST_CHAR_COUNT)
+      .split("&")
+      .map((s) => s.split("="))
+  );
 };
 
 const Router = (): React.ReactElement => {

--- a/frontend/src/styles/theme.ts
+++ b/frontend/src/styles/theme.ts
@@ -360,4 +360,10 @@ declare module "@mui/material/Button" {
   }
 }
 
+declare module "@mui/material/Checkbox" {
+  interface CheckboxPropsColorOverrides {
+    grey2: true;
+  }
+}
+
 export default theme;

--- a/frontend/src/styles/theme.ts
+++ b/frontend/src/styles/theme.ts
@@ -81,7 +81,7 @@ const theme = createTheme({
         padding: `16px 16px 16px 40px !important`,
       },
       miniSize: {
-        width: "298px",
+        width: "450px",
         height: "48px",
         padding: "8px 8px 8px 24px !important",
       },

--- a/frontend/src/utils/utils.ts
+++ b/frontend/src/utils/utils.ts
@@ -11,4 +11,10 @@ const getEllipisisStyle = (lineNumber: number) => {
   };
 };
 
-export { numToWon, getEllipisisStyle };
+const getFormattedDate = (dateString: string): string => {
+  const date = new Date(dateString);
+
+  return `${date.getMonth() + 1}월 ${date.getDate()}일`;
+};
+
+export { numToWon, getEllipisisStyle, getFormattedDate };

--- a/frontend/src/utils/utils.ts
+++ b/frontend/src/utils/utils.ts
@@ -2,4 +2,13 @@ const numToWon = (num: number) => {
   return num.toLocaleString();
 };
 
-export default numToWon;
+const getEllipisisStyle = (lineNumber: number) => {
+  return {
+    overflow: "hidden",
+    textOverflow: "ellipsis",
+    "-webkitLineClamp": lineNumber.toString(),
+    width: "100%",
+  };
+};
+
+export { numToWon, getEllipisisStyle };

--- a/frontend/src/utils/utils.ts
+++ b/frontend/src/utils/utils.ts
@@ -6,7 +6,7 @@ const getEllipisisStyle = (lineNumber: number) => {
   return {
     overflow: "hidden",
     textOverflow: "ellipsis",
-    "-webkitLineClamp": lineNumber.toString(),
+    WebkitLineClamp: lineNumber.toString(),
     width: "100%",
   };
 };

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -14,7 +14,8 @@
     "moduleResolution": "node",
     "isolatedModules": true,
     "noEmit": true,
-    "jsx": "react-jsx"
+    "jsx": "react-jsx",
+    "types": ["kakao.maps.d.ts"]
   },
   "include": ["src", "router"]
 }

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -5977,6 +5977,11 @@ jsonpointer@^5.0.0:
     array-includes "^3.1.4"
     object.assign "^4.1.2"
 
+kakao.maps.d.ts@^0.1.32:
+  version "0.1.32"
+  resolved "https://registry.yarnpkg.com/kakao.maps.d.ts/-/kakao.maps.d.ts-0.1.32.tgz#064880506706feb39eb641b0a7a71e5907f67cf9"
+  integrity sha512-xQULJE5XDOjfeK4Ba04AH4l/raTvHEoX72cbBhCUp6nS9rpJ7tEQgJP2A68kwTesnK5ug0Pa9LVEp+HfYHBsrg==
+
 kind-of@^6.0.2:
   version "6.0.3"
   resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-6.0.3.tgz#07c05034a6c349fa06e24fa35aa76db4580ce4dd"


### PR DESCRIPTION
## 🤷‍♂️ Description

close #94 

- 검색결과 페이지에서 검색필터를 보여준다.
  - 검색바
  - 검색결과 리스트 상단
- 검색결과 지도위 버튼이 동작한다.
  - 지도를 움직이며 검색하기 버튼이 올바르게 동작한다.
  - 확대 축소 버튼이 동작한다.

## 📝 Primary Commits

- [x] 검색결과 페이지 검색바에 검색필터를 보여준다. (미니바)
  - [x] 다시 검색버튼을 클릭하여 큰 검색바로 보여줄때에도 선택된 내용이 표시된다.
  - [x] 새로이 필터를 선택할 수 있도록 모달이 동작한다. 
- [x] 검색결과 페이지 리스트 상단에 검색 필터를 보여준다.
  - [x] 기존 지저분한 처리.. 다시 정리 
- [x] 검색결과 지도의 버튼이 동작한다.
  - [x] 지도를 움직이며 검색하기 버튼이 동작한다.
  - [x] 확대 축소버튼이 동작한다.
- [x] 비정상적인 쿼리스트링으로만 이뤄진 SearchResult페이지 오류 처리